### PR TITLE
Links to selected states in Rmd

### DIFF
--- a/tests/testthat/test-renderer1-knit-print.R
+++ b/tests/testthat/test-renderer1-knit-print.R
@@ -14,6 +14,14 @@ remDr$refresh()
 Sys.sleep(1)
 html <- getHTML()
 
+## This is a test for URL links displayed inside of animint Rmd.
+test_that("one url for each animint viz", {
+  nodes <- getNodeSet(html, "//table[@class='urltable']//a")
+  expect_equal(length(nodes), 4)
+  ## TODO maybe also test URLs which point to individual animints
+  ## e.g. http://localhost:4848/animint-htmltest/breakpoints/#{}
+})
+
 test_that("knit_print.animint renders five x axis titles", {
   nodes <- getNodeSet(html, "//text[@class='xtitle']")
   value.vec <- sapply(nodes, xmlValue)


### PR DESCRIPTION
Usually an animint shows a link to the currently selected state, which makes sense when it is the only animint on the web page.

In an Rmd with several animints it does not make sense to have a URL for selecting state (which animint would that refer to?)

however in an Rmd we may still show a link to the individual animint, with selected state.