### PR TITLE
Update DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Maintainer: Toby Dylan Hocking <toby.hocking@r-project.org>
 Description: A redesign of animint with a new syntax: clickSelects
     and showSelected are now specified as parameters.
 Depends:
-    R (>= 3.3.2),
+    R (>= 3.3.0),
     ggplot2Animint (>= 2.1.0)
 Imports:
     digest,
@@ -27,7 +27,6 @@ Suggests:
     shiny,
     htmltools,
     rmarkdown,
-    digest,
     testthat,
     RSelenium,
     XML,


### PR DESCRIPTION
To avoid WARNING during ```check()``` run: 

```R
* checking DESCRIPTION meta-information ... WARNING
Dependence on R version '3.3.2' not with patch level 0
```
And also ```check()``` suggest mentioning packages only at one place either in Imports or Suggests:

so removing digest from suggests