### PR TITLE
Update .Rbuildignore: Adding file(s) to ignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,3 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^\.travis\.yml$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,7 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^\.travis\.yml$
+^IDEAS\.html$
+^IDEAS\.org$
+^README\.org$
+^tableau-notes\.org$


### PR DESCRIPTION
To avoid WARNING during ```check()``` run: 

```R
* checking DESCRIPTION meta-information ... WARNING
Dependence on R version '3.3.2' not with patch level 0
```
And also ```check()``` suggest mentioning packages only at one place either in Imports or Suggests:

so removing digest from suggests