### PR TITLE
Importing few packages and cross-reference changes

### DIFF
--- a/R/animint.R
+++ b/R/animint.R
@@ -3,7 +3,11 @@
 #' @return nothing, info is stored in meta.
 #' @export
 #' @import plyr
+#' @import utils
+#' @import stats
+#' @import grDevices
 #' @import ggplot2Animint
+#' @importFrom ggplot2Animint zeroGrob
 parsePlot <- function(meta, plot, plot.name){
   ## adding data and mapping to each layer from base plot, if necessary
   for(layer.i in seq_along(plot$layers)) {
@@ -859,7 +863,7 @@ saveLayer <- function(l, d, meta, layer_name, ggplot, built, AnimationInfo){
 #' @param css.file character string for non-empty css file to include. Provided file will be copied to the output directory as styles.css
 #' @return invisible list of ggplots in list format.
 #' @export
-#' @seealso \code{\link{ggplot2}}
+#' @seealso \code{\link[ggplot2Animint]{ggplot_build}}
 #' @example inst/examples/animint.R
 animint2dir <- function(plot.list, out.dir = tempfile(),
                         json.file = "plot.json", open.browser = interactive(),


### PR DESCRIPTION
These changes are resolving following WARNINGs or NOTEs during ```check()``` :


First:
```R
Consider adding
  importFrom("grDevices", "col2rgb", "rgb")
  importFrom("stats", "na.omit", "setNames")
  importFrom("utils", "browseURL", "head", "packageVersion", "str",
             "tail", "write.table")
to your NAMESPACE file.

```

NOTE: All the NOTE(s) mentioned above have not been cleared up, working on it. 

Second:

```R
Missing link or links in documentation object 'animint2dir.Rd':
  'ggplot2'

See section 'Cross-references' in the 'Writing R Extensions' manual.
```