### PR TITLE
Fix test warnings

### DIFF
--- a/tests/testthat/test-renderer1-facet-lines.R
+++ b/tests/testthat/test-renderer1-facet-lines.R
@@ -30,7 +30,8 @@ wb.facets <-
                    data=SCATTER(not.na))+
          scale_size_animint(breaks=10^(5:9))+
          facet_grid(.~facet, scales="free")+
-         geom_text(aes(5, 85, label=paste0("year = ", year)),
+         geom_text(aes(5, 85, label=paste0("year = ", year), 
+                  key=year),
                    showSelected="year",
                    data=SCATTER(years)),
        time=list(variable="year",ms=3000),

--- a/tests/testthat/test-renderer1-facet-space.R
+++ b/tests/testthat/test-renderer1-facet-space.R
@@ -32,7 +32,7 @@ test_that("some horizontal space between panels", {
     second <- xmlAttrs(rect.list[[2]])
     second.left <- as.numeric(second[["x"]])
     second.right <- second.left+as.numeric(second[["width"]])
-    expect_less_than(first.right, second.left)
+    expect_lt(first.right, second.left)
     ## Also make sure the xtitle is placed in the middle of the
     ## plotting region.
     xpath <- sprintf('//svg[@id="plot_%s"]//text[@class="xtitle"]', plot.name)
@@ -124,7 +124,7 @@ test_that("some vertical space between panels", {
     second <- xmlAttrs(rect.list[[2]])
     second.top <- as.numeric(second[["y"]])
     second.bottom <- second.top+as.numeric(second[["height"]])
-    expect_less_than(first.bottom, second.top)
+    expect_lt(first.bottom, second.top)
     ## Also check that ytitle is placed in the middle of the plotting
     ## region.
     xpath <- sprintf('//svg[@id="plot_%s"]//text[@class="ytitle"]', plot.name)

--- a/tests/testthat/test-renderer1-facet-trivial.R
+++ b/tests/testthat/test-renderer1-facet-trivial.R
@@ -32,7 +32,7 @@ test_that("facet_grid(1 row and/or 1 column) is fine", {
     trans.mat <- str_match_perl(xtitle.attrs[["transform"]], translatePattern)
     trans.y <- as.numeric(trans.mat[, "y"])
     ## 400 is the default animint plot height.
-    expect_less_than(trans.y, 400)
+    expect_lt(trans.y, 400)
   }
   expect_axes("kk", 1, 1)
   expect_axes("kx", 1, 1)

--- a/tests/testthat/test-renderer1-panels.R
+++ b/tests/testthat/test-renderer1-panels.R
@@ -1,13 +1,13 @@
 acontext("Panel background")
 p2 <- ggplot() +
   geom_point(aes(Petal.Length, Petal.Width,
-                 colour = Species, size = Species), data = iris) +
+                 colour = Species), data = iris) +
   ggtitle("Petal Data") +
   theme_bw()
 viz <- list(
   sepal=ggplot() +
     geom_point(aes(Sepal.Length, Sepal.Width,
-                   colour = Species, size = Species), data = iris) +
+                   colour = Species), data = iris) +
     theme_grey() + 
     theme(panel.background = element_rect(fill = "lightblue"),
           panel.border = element_rect(fill = NA,

--- a/tests/testthat/test-renderer1-text.R
+++ b/tests/testthat/test-renderer1-text.R
@@ -26,9 +26,9 @@ test_that("text may contain commas and parentheses", {
   info <- animint2HTML(viz)
   geom <- getNodeSet(info$html, '//text[@class="geom"]')
   txt <- sapply(geom, xmlValue)
-  expect_that(any(grepl("\\.", txt)), is_true())
-  expect_that(any(grepl("\\(", txt)), is_true())
-  expect_that(any(grepl(",", txt)), is_true())
+  expect_true(any(grepl("\\.", txt)))
+  expect_true(any(grepl("\\(", txt)))
+  expect_true(any(grepl(",", txt)))
 })
 
 ### Test text rotation option

--- a/tests/testthat/test-renderer1-tooltip.R
+++ b/tests/testthat/test-renderer1-tooltip.R
@@ -21,14 +21,17 @@ viz <-
        scale_size_animint(breaks=10^(5:9))+
        geom_rect(aes(xmin=45, xmax=70,
                      ymin=8, ymax=10,
-                     tooltip=paste(countries, "not NA in", year)),
+                     tooltip=paste(countries, "not NA in", year),
+                     key=year),
                  showSelected="year",
                  data=years, color="yellow")+
        geom_rect(aes(xmin=35, xmax=40,
-                     ymin=2, ymax=2.5),
+                     ymin=2, ymax=2.5,
+                     key=year),
                  showSelected="year",
                  data=years, color="orange")+
-       geom_text(aes(55, 9, label=paste("year =", year)),
+       geom_text(aes(55, 9, label=paste("year =", year),
+                     key=year),
                  showSelected="year",
                  data=years),
 
@@ -40,7 +43,7 @@ viz <-
 
        bar=ggplot()+
        theme_animint(height=2400)+
-       geom_bar(aes(country, life.expectancy, fill=region),
+       geom_bar(aes(country, life.expectancy, fill=region, key=year),
                 showSelected="year", clickSelects="country",
                 data=WorldBank, stat="identity", position="identity")+
        coord_flip(),

--- a/tests/testthat/test-renderer2-widerect.R
+++ b/tests/testthat/test-renderer2-widerect.R
@@ -30,7 +30,7 @@ getBounds <- function(geom.class){
 test_that("bottom of widerect is above line", {
   rect.bounds <- getBounds("geom1_widerect_gg")
   line.bounds <- getBounds("geom2_line_gg")
-  expect_less_than(rect.bounds$bottom, line.bounds$top)
+  expect_lt(rect.bounds$bottom, line.bounds$top)
 })
 
 data(WorldBank, package = "animint2")
@@ -89,7 +89,8 @@ wb.facets <-
                  data=SCATTER(not.na))+
        scale_size_animint(breaks=10^(5:9))+
        facet_grid(side ~ top, scales="free")+
-       geom_text(aes(5, 85, label=paste0("year = ", year)),
+       geom_text(aes(5, 85, label=paste0("year = ", year), 
+                key=year),
                  showSelected="year",
                  data=SCATTER(years)),
 

--- a/tests/testthat/test-renderer3-ChromHMMinit.R
+++ b/tests/testthat/test-renderer3-ChromHMMinit.R
@@ -81,5 +81,5 @@ test_that("animation starts by default", {
   updated.fill.vec <- getFill()
   expect_equal(length(updated.fill.vec), 225)
   n.different <- sum(initial.fill.vec != updated.fill.vec)
-  expect_more_than(n.different, 0)
+  expect_gt(n.different, 0)
 })

--- a/tests/testthat/test-renderer3-knn.R
+++ b/tests/testthat/test-renderer3-knn.R
@@ -156,7 +156,7 @@ test_that("1 <line> rendered for Bayes error", {
   expect_equal(length(before$Bayes), 1)
 })
 test_that("Bayes error <line> inside of border_rect", {
-  expect_less_than(before$Bayes.x2, before$border.right)
+  expect_lt(before$Bayes.x2, before$border.right)
 })
 test_that("6 <path> rendered for KNN boundary", {
   expect_equal(length(before$boundary.KNN), 6)

--- a/tests/testthat/test-renderer3-stat-bin.R
+++ b/tests/testthat/test-renderer3-stat-bin.R
@@ -19,7 +19,7 @@ test_that("error for stat=bin and showSelected", {
   gg <- ggplot() +
     theme_bw()+
     theme(panel.margin=grid::unit(0, "lines"))+
-    geom_bar(
+    geom_histogram(
       aes(count, group=stack, fill=stack),
       showSelected="facet",
       binwidth=1,
@@ -40,7 +40,7 @@ test_that("no warning for stat=bin without showSelected", {
   gg <- ggplot() +
     theme_bw()+
     theme(panel.margin=grid::unit(0, "lines"))+
-    geom_bar(
+    geom_histogram(
       aes(count, group=stack, fill=stack),
       binwidth=1,
       data = df,


### PR DESCRIPTION
Fix most test warnings in CI. The left warnings:
1. some ```aes(key)``` warnings were caused by ```make_test()``` functions, since when I substitute ```make_text(WorldBank, 55, 9, "year")``` with ```geom_text(aes(5, 85, label=paste0("year = ", year), key=year), showSelected="year", data=WorldBank)``` the warning would disappear. 
```make_test()``` func makes code more concise, and I don't know should replace it or not.
2. ```aes(key)``` warning in test-renderer3-lilac_chaser.R is inevitable, which makes a test failure if add the ```key``` attribute in aes