### PR TITLE
Add support for alpha_off 

### DIFF
--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -1047,6 +1047,15 @@ var animint = function (to_select, json_file) {
       }
       return a;
     };
+    const get_alpha_off = function (d) {
+      let a;
+      if (aes.hasOwnProperty("alpha_off") && d.hasOwnProperty("alpha_off")) {
+        a = d["alpha_off"];
+      } else {
+        a = base_opacity;
+      }
+      return a;
+    };
     var size = 2;
     if(g_info.geom == "text"){
       size = 12;
@@ -1570,7 +1579,9 @@ var animint = function (to_select, json_file) {
 	"opacity":{
 	  "mouseout":function (d) {
 	    var alpha_on = get_alpha(d);
-	    var alpha_off = get_alpha(d) - 0.5;
+      // 
+      let alpha_off = get_alpha_off(d);
+	    // var alpha_off = get_alpha(d) - 0.5;
 	    if(has_clickSelects){
               return ifSelectedElse(d.clickSelects, g_info.aes.clickSelects,
 				    alpha_on, alpha_off);

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -1035,12 +1035,13 @@ var animint = function (to_select, json_file) {
     // TODO: standardize this code across aes/styles.
     let base_opacity;
     let off_opacity;
-    if (g_info.params.alpha) {
+    // Explicitly check if it has the property, allows 0 as valid value
+    if (g_info.params.hasOwnProperty("alpha")) {
       base_opacity = g_info.params.alpha;
     } else {
       base_opacity = 1;
     }
-    if (g_info.params.alpha_off) {
+    if (g_info.params.hasOwnProperty("alpha_off")) {
       off_opacity = g_info.params.alpha_off;
     } else {
       off_opacity = base_opacity - 0.5;
@@ -1059,6 +1060,8 @@ var animint = function (to_select, json_file) {
       let a;
       if (aes.hasOwnProperty("alpha_off") && d.hasOwnProperty("alpha_off")) {
         a = d["alpha_off"];
+      } else if (g_info.params.hasOwnProperty("alpha_off")) {
+        a = g_info.params.alpha_off;
       } else if (aes.hasOwnProperty("alpha") && d.hasOwnProperty("alpha")) {
         a = d["alpha"] - 0.5;
       } else {

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -1039,6 +1039,8 @@ var animint = function (to_select, json_file) {
     }
     if (g_info.params.alpha_off) {
       off_opacity = g_info.params.alpha_off;
+    } else {
+      off_opacity = base_opacity - 0.5;
     }
     //alert(g_info.classed+" "+base_opacity);
     var get_alpha = function (d) {
@@ -1054,6 +1056,8 @@ var animint = function (to_select, json_file) {
       let a;
       if (aes.hasOwnProperty("alpha_off") && d.hasOwnProperty("alpha_off")) {
         a = d["alpha_off"];
+      } else if (aes.hasOwnProperty("alpha") && d.hasOwnProperty("alpha")) {
+        a = d["alpha"] - 0.5;
       } else {
         a = off_opacity;
       }

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -1033,9 +1033,12 @@ var animint = function (to_select, json_file) {
     var panel_g_element = layer_g_element.select("g.PANEL" + PANEL);
     var elements = panel_g_element.selectAll(".geom");
     // TODO: standardize this code across aes/styles.
-    var base_opacity = 1;
+    let base_opacity;
+    let off_opacity;
     if (g_info.params.alpha) {
       base_opacity = g_info.params.alpha;
+    } else {
+      base_opacity = 1;
     }
     if (g_info.params.alpha_off) {
       off_opacity = g_info.params.alpha_off;

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -1037,6 +1037,9 @@ var animint = function (to_select, json_file) {
     if (g_info.params.alpha) {
       base_opacity = g_info.params.alpha;
     }
+    if (g_info.params.alpha_off) {
+      off_opacity = g_info.params.alpha_off;
+    }
     //alert(g_info.classed+" "+base_opacity);
     var get_alpha = function (d) {
       var a;
@@ -1052,7 +1055,7 @@ var animint = function (to_select, json_file) {
       if (aes.hasOwnProperty("alpha_off") && d.hasOwnProperty("alpha_off")) {
         a = d["alpha_off"];
       } else {
-        a = base_opacity;
+        a = off_opacity;
       }
       return a;
     };

--- a/tests/testthat/test-renderer2-opacity.R
+++ b/tests/testthat/test-renderer2-opacity.R
@@ -1,0 +1,265 @@
+# Consider matrix of combinations of alpha and alpha_off in aes parameter
+# vs geom parameter.
+# Each can be one of geom, aes, or none.
+# The test matrix of tuples, (alpha, alpha_off), is:
+# (geom, geom), (geom, aes), (geom, none),
+# (aes,  geom), (aes,  aes), (aes,  none),
+# (none, geom), (none, aes), (none, none)
+
+# The (alpha, none) column is the original behavior, where the alpha of
+# unselected values is the original alpha - 0.5.
+# (none, none) is the base case, where the selection uses alpha = 1, and the
+# unselected use the original - 0.5 formula.
+# (geom, geom) behaves similar to (none, none), but the alpha is set to any
+# value the user selects.
+# (geom, aes) gives the selection a defined alpha, and unselected points use
+# the aes value.
+# (aes, aes) gives both the selection and unselected items alpha from their aes.
+# (none, geom) gives selected points the default opacity of 1, and unselected
+# points the provided opacity.
+# (none, aes) gives selected points the default opacity of 1, and unselected
+# points use the aes value.
+
+acontext("User defined opacity")
+
+
+alpha_seq <- seq(0.1, 1, by = 0.1)
+alpha_rev_seq <- seq(1, 0.1, by = -0.1)
+
+plot.dt <- data.frame(
+  x = 1:10,
+  y = 1:10,
+  alpha_seq = alpha_seq,
+  alpha_rev_seq = alpha_rev_seq
+)
+
+alpha_on <- 0.8
+alpha_off <- 0.2
+
+scatter.plot <- ggplot() +
+  geom_point(
+    data = plot.dt,
+    size = 5,
+    aes(x, y, alpha = alpha_seq)
+  ) +
+  ggtitle("Scatter plot with non-interactive alpha")
+
+geom.geom.plot <- ggplot() +
+geom_point(
+  data = plot.dt,
+  alpha = alpha_on,
+  alpha_off = alpha_off,
+  size = 5,
+  clickSelects = "y",
+  aes(x, y, id=paste0("y", y))
+) +
+ggtitle("Scatter plot with (geom, geom)")
+
+geom.aes.plot <- ggplot() +
+  geom_point(
+    data = plot.dt,
+    alpha = alpha_on,
+    size = 5,
+    clickSelects = "y",
+    aes(x, y, alpha_off = alpha_seq)
+  ) +
+  ggtitle("Scatter plot with (geom, aes)")
+
+geom.none.plot <- ggplot() +
+  geom_point(
+    data = plot.dt,
+    alpha = alpha_on,
+    size = 5,
+    clickSelects = "y",
+    aes(x, y)
+  ) +
+  ggtitle("Scatter plot with (geom, none)")
+
+# TODO: fix this, right now behaving like (aes, none)
+aes.geom.plot <- ggplot() +
+  geom_point(
+    data = plot.dt,
+    alpha_off = alpha_off,
+    size = 5,
+    clickSelects = "y",
+    aes(x, y, alpha = alpha_seq)
+  ) +
+  ggtitle("Scatter plot with (aes, geom)")
+
+aes.aes.plot <- ggplot() +
+  geom_point(
+    data = plot.dt,
+    size = 5,
+    clickSelects = "y",
+    aes(x, y, alpha = alpha_seq, alpha_off = alpha_rev_seq)
+  ) +
+  ggtitle("Scatter plot with (aes, aes)")
+
+aes.none.plot <- ggplot() +
+  geom_point(
+    data = plot.dt,
+    size = 5,
+    clickSelects = "y",
+    aes(x, y, alpha = alpha_seq)
+  ) +
+  ggtitle("Scatter plot with (aes, none)")
+
+none.geom.plot <- ggplot() +
+  geom_point(
+    data = plot.dt,
+    size = 5,
+    alpha_off = alpha_off,
+    clickSelects = "y",
+    aes(x, y)
+  ) +
+  ggtitle("Scatter plot with (none, geom)")
+
+none.aes.plot <- ggplot() +
+  geom_point(
+    data = plot.dt,
+    size = 5,
+    clickSelects = "y",
+    aes(x, y, alpha_off = alpha_seq)
+  ) +
+  ggtitle("Scatter plot with (none, aes)")
+
+none.none.plot <- ggplot() +
+  geom_point(
+    data = plot.dt,
+    size = 5,
+    clickSelects = "y",
+    aes(x, y)
+  ) +
+  ggtitle("Scatter plot with (none, none)")
+
+scatter.viz <- list()
+scatter.viz$noninteractive <- scatter.plot
+scatter.viz$geomGeom <- geom.geom.plot
+scatter.viz$geomAes <- geom.aes.plot
+scatter.viz$geomNone <- geom.none.plot
+scatter.viz$aesGeom <- aes.geom.plot
+scatter.viz$aesAes <- aes.aes.plot
+scatter.viz$aesNone <- aes.none.plot
+scatter.viz$noneGeom <- none.geom.plot
+scatter.viz$noneAes <- none.aes.plot
+scatter.viz$noneNone <- none.none.plot
+
+animint2HTML(scatter.viz)
+
+
+get_points_geom <- function(geom, full.node.set) {
+  getNodeSet(full.node.set, paste0("//svg[@id='plot_", geom, "']//circle"))
+}
+
+opacity_extract_pattern <- "(?<=opacity: )(\\-?\\d*\\.?\\d*)"
+
+get_opacity <- function (node) {
+    style <- xmlAttrs(node)[["style"]]
+    as.numeric(
+      regmatches(style, regexpr(opacity_extract_pattern, style, perl = TRUE)))
+      }
+
+# It can't hurt to make sure we explicitly set the initial state,
+# just in case some browser or Selenium update changes things
+before.update.nodes <- clickHTML(id=paste0("y", 1))
+after.update.nodes <- clickHTML(id=paste0("y", 2))
+
+
+test_that("(geom, geom) opacity updates", {
+  before.nodes <- get_points_geom("geomGeom", before.update.nodes)
+  after.nodes <- get_points_geom("geomGeom", after.update.nodes)
+  before.opacities <- sapply(before.nodes, get_opacity)
+  after.opacities <- sapply(after.nodes, get_opacity)
+  expect_equal(before.opacities[1], alpha_on)
+  expect_equal(before.opacities[2], alpha_off)
+  expect_equal(after.opacities[1], alpha_off)
+  expect_equal(after.opacities[2], alpha_on)
+})
+
+test_that("(geom, aes) opacity updates", {
+  before.nodes <- get_points_geom("geomAes", before.update.nodes)
+  after.nodes <- get_points_geom("geomAes", after.update.nodes)
+  before.opacities <- sapply(before.nodes, get_opacity)
+  after.opacities <- sapply(after.nodes, get_opacity)
+  expect_equal(before.opacities[1], alpha_on)
+  expect_equal(before.opacities[2], alpha_seq[2])
+  expect_equal(after.opacities[1], alpha_seq[1])
+  expect_equal(after.opacities[2], alpha_on)
+})
+
+test_that("(geom, none) opacity updates", {
+  before.nodes <- get_points_geom("geomNone", before.update.nodes)
+  after.nodes <- get_points_geom("geomNone", after.update.nodes)
+  before.opacities <- sapply(before.nodes, get_opacity)
+  after.opacities <- sapply(after.nodes, get_opacity)
+  expect_equal(before.opacities[1], alpha_on)
+  expect_equal(before.opacities[2], alpha_on - 0.5)
+  expect_equal(after.opacities[1], alpha_on - 0.5)
+  expect_equal(after.opacities[2], alpha_on)
+})
+
+test_that("(aes, geom) opacity update", {
+  before.nodes <- get_points_geom("aesGeom", before.update.nodes)
+  after.nodes <- get_points_geom("aesGeom", after.update.nodes)
+  before.opacities <- sapply(before.nodes, get_opacity)
+  after.opacities <- sapply(after.nodes, get_opacity)
+  expect_equal(before.opacities[1], alpha_seq[1])
+  expect_equal(before.opacities[2], alpha_off)
+  expect_equal(after.opacities[1], alpha_off)
+  expect_equal(after.opacities[2], alpha_seq[2])
+})
+
+test_that("(aes, aes) opacity updates", {
+  before.nodes <- get_points_geom("aesAes", before.update.nodes)
+  after.nodes <- get_points_geom("aesAes", after.update.nodes)
+  before.opacities <- sapply(before.nodes, get_opacity)
+  after.opacities <- sapply(after.nodes, get_opacity)
+  expect_equal(before.opacities[1], alpha_seq[1])
+  expect_equal(before.opacities[2], alpha_rev_seq[2])
+  expect_equal(after.opacities[1], alpha_rev_seq[1])
+  expect_equal(after.opacities[2], alpha_seq[2])
+})
+
+test_that("(aes, none) opacity updates", {
+  before.nodes <- get_points_geom("aesNone", before.update.nodes)
+  after.nodes <- get_points_geom("aesNone", after.update.nodes)
+  before.opacities <- sapply(before.nodes, get_opacity)
+  after.opacities <- sapply(after.nodes, get_opacity)
+  expect_equal(before.opacities[1], alpha_seq[1])
+  expect_equal(before.opacities[2], alpha_seq[2] - 0.5)
+  expect_equal(after.opacities[1], alpha_seq[1] - 0.5)
+  expect_equal(after.opacities[2], alpha_seq[2])
+})
+
+test_that("(none, geom) opacity updates", {
+  before.nodes <- get_points_geom("noneGeom", before.update.nodes)
+  after.nodes <- get_points_geom("noneGeom", after.update.nodes)
+  before.opacities <- sapply(before.nodes, get_opacity)
+  after.opacities <- sapply(after.nodes, get_opacity)
+  expect_equal(before.opacities[1], 1)
+  expect_equal(before.opacities[2], alpha_off)
+  expect_equal(after.opacities[1], alpha_off)
+  expect_equal(after.opacities[2], 1)
+})
+
+test_that("(none, aes) opacity updates", {
+  before.nodes <- get_points_geom("noneAes", before.update.nodes)
+  after.nodes <- get_points_geom("noneAes", after.update.nodes)
+  before.opacities <- sapply(before.nodes, get_opacity)
+  after.opacities <- sapply(after.nodes, get_opacity)
+  expect_equal(before.opacities[1], 1)
+  expect_equal(before.opacities[2], alpha_seq[2])
+  expect_equal(after.opacities[1], alpha_seq[1])
+  expect_equal(after.opacities[2], 1)
+})
+
+test_that("(none, none) opacity updates", {
+  before.nodes <- get_points_geom("noneNone", before.update.nodes)
+  after.nodes <- get_points_geom("noneNone", after.update.nodes)
+  before.opacities <- sapply(before.nodes, get_opacity)
+  after.opacities <- sapply(after.nodes, get_opacity)
+  expect_equal(before.opacities[1], 1)
+  expect_equal(before.opacities[2], 1 - 0.5)
+  expect_equal(after.opacities[1], 1 - 0.5)
+  expect_equal(after.opacities[2], 1)
+})


### PR DESCRIPTION
Allows the user to specify an `alpha_off` parameter in the `geom` parameters or the `aes` parameters and use that opacity as the deselected opacity, instead of the previous default of `alpha - 0.5`. Replicates the default behavior if an alpha_off parameter is not provided.