### PR TITLE
Fix warning in 'make_text' func, renderer3 and compiler

### DIFF
--- a/R/z_geoms.R
+++ b/R/z_geoms.R
@@ -294,6 +294,6 @@ make_text <- function(data, x, y, label.var, format=NULL){
   }
   stopifnot(is.function(format))
   data$label <- format(data$label)
-  a <- aes_string(x="x",y="y",label="label")
+  a <- aes_string(x="x",y="y",label="label",key="label")
   geom_text(a, showSelected=label.var, data)
 }

--- a/tests/testthat/test-compiler-animation.R
+++ b/tests/testthat/test-compiler-animation.R
@@ -39,7 +39,7 @@ data(WorldBank, package = "animint2")
 motion <-
   list(scatter=ggplot()+
          geom_point(aes(life.expectancy, fertility.rate,
-                        colour=region, size=population),
+                        colour=region, size=population, key=year),
                         clickSelects="country",
                         showSelected="year",
                   data=WorldBank)+

--- a/tests/testthat/test-compiler-build.r
+++ b/tests/testthat/test-compiler-build.r
@@ -32,13 +32,13 @@ test_that("position aesthetics coerced to correct type", {
 test_that("non-position aesthetics are mapped", {
   l1 <- ggplot(df, aes(x, y, fill = z, colour = z, shape = z, size = z)) +
     geom_point()
-  d1 <- layer_data(l1, 1)
+  suppressWarnings(d1 <- layer_data(l1, 1))
 
   expect_equal(sort(names(d1)), sort(c("x", "y", "fill", "group",
     "colour", "shape", "size", "PANEL", "alpha", "stroke")))
 
   l2 <- l1 + scale_colour_manual(values = c("blue", "red", "yellow"))
-  d2 <- layer_data(l2, 1)
+  suppressWarnings(d2 <- layer_data(l2, 1))
   expect_equal(d2$colour, c("blue", "red", "yellow"))
 })
 

--- a/tests/testthat/test-compiler-data.r
+++ b/tests/testthat/test-compiler-data.r
@@ -9,7 +9,7 @@ test_that("stringsAsFactors doesn't affect results", {
     base <- ggplot(mapping = aes(x, y)) + geom_point()
     xlabels <- function(x) x$panel$ranges[[1]]$x.labels
 
-    options(stringsAsFactors = TRUE)
+    suppressWarnings(options(stringsAsFactors = TRUE))
     char_true <- ggplot_build(base %+% dat.character)
     factor_true <- ggplot_build(base %+% dat.factor)
 

--- a/tests/testthat/test-compiler-gist.R
+++ b/tests/testthat/test-compiler-gist.R
@@ -73,7 +73,7 @@ viz.chunk.none <-
                    validate_params = FALSE)+
          scale_size_animint(breaks=10^(5:9))+
          facet_grid(side ~ top, scales="free")+
-         geom_text(aes(5, 85, label=paste0("year = ", year)),
+         geom_text(aes(5, 85, label=paste0("year = ", year), key=year),
                        showSelected="year",
                    data=SCATTER(years)),
        time=list(variable="year",ms=3000),

--- a/tests/testthat/test-compiler-plot-named-timexxx.R
+++ b/tests/testthat/test-compiler-plot-named-timexxx.R
@@ -7,7 +7,7 @@ not.na[not.na$country=="Kuwait", "population"] <- 1700000
 viz <-
   list(scatter=ggplot()+
          geom_point(aes(life.expectancy, fertility.rate,
-                        colour=region, size=population),
+                        colour=region, size=population, key=year),
                     clickSelects="country",
                     showSelected="year",
                     data=not.na)+

--- a/tests/testthat/test-renderer3-lilac_chaser.R
+++ b/tests/testthat/test-renderer3-lilac_chaser.R
@@ -50,7 +50,7 @@ vi_lilac_chaser <- function(np = 10,
 }
 
 plots <- vi_lilac_chaser()
-info <- animint2HTML(plots)
+suppressWarnings(info <- animint2HTML(plots))
 
 test_that("axes hidden", {
     # info <- animint2HTML(viz)

--- a/tests/testthat/test-renderer3-lilac_chaser.R
+++ b/tests/testthat/test-renderer3-lilac_chaser.R
@@ -13,16 +13,25 @@ vi_lilac_chaser <- function(np = 10,
     # Get data in a data-frame to pass to ggplot
     df <- data.frame()
     for (i in 1:np) {
-        df <- rbind(df, cbind(sin(x[-i]), cos(x[-i]), ptn = i))}
-    colnames(df) <- c("sinv", "cosv", "ptn")
+      df <- rbind(df, cbind(sin(x), cos(x), ptn = 1:np, grp = i))
+    }
+    colnames(df) <- c("sinv", "cosv", "ptn", "grp")
+    
+    # For each group, one point coordinate should be set to NA to disappear
+    for (i in 1:np) {
+      df <- within(df, {
+        sinv[grp == i & ptn == i] <- NA
+        cosv[grp == i & ptn == i] <- NA
+      })
+    }
 
 
     # Plot to display the points and the '+' mark in the middle
     p1 <- ggplot(data = df) +
         # Display the points
         geom_point(data = df,
-                   aes(x = sinv, y = cosv),
-                   showSelected = "ptn",
+                   aes(x = sinv, y = cosv, key = ptn), # key aesthetic for animated transitions!
+                   showSelected = "grp",
                    col = col,
                    size = p.size) +
         # Display the '+' mark
@@ -44,13 +53,13 @@ vi_lilac_chaser <- function(np = 10,
 
     # Automate using animint taking point number 'ptn' as variable
     plots <- list(plot1 = p1)
-    plots$time <- list(variable = "ptn", ms = 150)
-    plots$duration <- list(ptn=0)
+    plots$time <- list(variable = "grp", ms = 150)
+    plots$duration <- list(grp=0)
     return(plots)
 }
 
 plots <- vi_lilac_chaser()
-suppressWarnings(info <- animint2HTML(plots))
+info <- animint2HTML(plots)
 
 test_that("axes hidden", {
     # info <- animint2HTML(viz)


### PR DESCRIPTION
Update ```make_text()``` so some of the ```aes(key)``` warnings disappear in test suites. The original PR is [here](https://github.com/tdhock/animint2/pull/58).