### PR TITLE
fix legend entry text size with theme grey

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: animint2
 Title: Animated Interactive Grammar of Graphics
-Version: 2022.8.31
+Version: 2022.9.14
 URL: https://github.com/tdhock/animint2
 BugReports: https://github.com/tdhock/animint2/issues
 Authors@R: c(

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -270,4 +270,4 @@ Collate:
     'z_scales.R'
     'z_theme_animint.R'
     'z_transformShape.R'
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1

--- a/NEWS
+++ b/NEWS
@@ -16,6 +16,10 @@ the selector called "arclength" with the value in column
 allow configurable text size via
 theme(axis.title=element_text(size=20)) etc.
 
+2022.9.14
+
+Allow configurable legend/axis text size via theme.
+
 2022.8.31
 
 User-configurable selection styles, alpha_off and colour_off.

--- a/R/z_animint.R
+++ b/R/z_animint.R
@@ -145,13 +145,10 @@ parsePlot <- function(meta, plot, plot.name){
     # theme settings are shared across panels
     axis.text <- theme.pars[[s("axis.text.%s")]]
     ## TODO: also look at axis.text! (and text?)
-    size <- calc_element(s("axis.text.%s"), theme.pars)$size
+    size <- getTextSize(s("axis.text.%s"), theme.pars)
     anchor <- hjust2anchor(axis.text$hjust)
     angle <- if(is.numeric(axis.text$angle)){
       -axis.text$angle
-    }
-    if(is.null(size)){
-      size <- 11
     }
     if(is.null(angle)){
       angle <- 0
@@ -163,7 +160,7 @@ parsePlot <- function(meta, plot, plot.name){
         "end"
       }
     }
-    plot.info[[s("%ssize")]] <- as.numeric(size)
+    plot.info[[s("%ssize")]] <- size
     plot.info[[s("%sanchor")]] <- as.character(anchor)
     plot.info[[s("%sangle")]] <- as.numeric(angle)
     # translate panel specific axis info
@@ -731,17 +728,8 @@ getLegendList <- function(plistextra){
     discrete.vec <- sapply(scale.list, inherits, "ScaleDiscrete")
     is.discrete <- all(discrete.vec)
     gdefs[[leg]]$is.discrete <- is.discrete
-    is.complete.theme <- attr(plot$theme, "complete")
-    gdefs[[leg]]$text_size <- if(!is.null(plot$theme$legend.text$size) && !is.complete.theme) {
-      calc_element("legend.text", theme)$size
-    } else{
-      16
-    }
-    gdefs[[leg]]$title_size <- if(!is.null(plot$theme$legend.title$size) && !is.complete.theme) {
-      calc_element("legend.title", theme)$size
-    } else{
-      16
-    }
+    gdefs[[leg]]$text_size <- getTextSize("legend.text", theme)
+    gdefs[[leg]]$title_size <- getTextSize("legend.title", theme)
     ## get the name of the legend/selection variable.
     var.list <- list()
     for(layer.i in seq_along(plot$layers)) {

--- a/R/z_animint.R
+++ b/R/z_animint.R
@@ -731,12 +731,13 @@ getLegendList <- function(plistextra){
     discrete.vec <- sapply(scale.list, inherits, "ScaleDiscrete")
     is.discrete <- all(discrete.vec)
     gdefs[[leg]]$is.discrete <- is.discrete
-    gdefs[[leg]]$text_size <- if(!is.null(plot$theme$legend.text$size)) {
+    is.complete.theme <- attr(plot$theme, "complete")
+    gdefs[[leg]]$text_size <- if(!is.null(plot$theme$legend.text$size) && !is.complete.theme) {
       calc_element("legend.text", theme)$size
     } else{
       16
     }
-    gdefs[[leg]]$title_size <- if(!is.null(theme$legend.title$size)) {
+    gdefs[[leg]]$title_size <- if(!is.null(plot$theme$legend.title$size) && !is.complete.theme) {
       calc_element("legend.title", theme)$size
     } else{
       16

--- a/R/z_animintHelpers.R
+++ b/R/z_animintHelpers.R
@@ -745,6 +745,23 @@ getLegend <- function(mb){
 }
 
 
+#' Function to process text size with different types of unit
+#' @param element.name The name of the theme element
+#' @param theme combined theme from plot_theme()
+#' @return character of text size, with unit pt/px
+getTextSize <- function(element.name, theme){
+  input.size <- calc_element(element.name, theme)$size
+  if(is.character(input.size)){
+    if(!grepl('^[0-9]+(px|pt)$', input.size)){
+      default.size <- calc_element(element.name, theme_gray())$size
+      warning(sprintf("%s is not numeric nor character ending with \'pt\' or \'px\', will be default %dpt", element.name, default.size))
+      return(paste(default.size, "pt", sep=""))
+    }
+    return(input.size)
+  }
+  paste(input.size, "pt", sep="")
+}
+
 ##' Save the common columns for each tsv to one chunk
 ##' @param built data.frame of built data.
 ##' @param chunk.vars which variables to chunk on.

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -616,7 +616,7 @@ var animint = function (to_select, json_file) {
 	}
 	xaxis_g.selectAll("text")
 	  .style("text-anchor", p_info.xanchor)
-	  .style("font-size", p_info.xsize + "px")
+	  .style("font-size", p_info.xsize)
 	  .attr("transform", "rotate(" + p_info.xangle + " 0 9)");
       }
       if(draw_y){
@@ -637,7 +637,7 @@ var animint = function (to_select, json_file) {
 	  axis_path.remove();
 	}
   yaxis_g.selectAll(".tick text")
-    .style("font-size", p_info.ysize + "px");
+    .style("font-size", p_info.ysize);
       }
 
       if(!axis.xline) {
@@ -2143,7 +2143,7 @@ var animint = function (to_select, json_file) {
 	.attr("colspan", 2)
         .text(l_info.title)
         .attr("class", legend_class)
-        .style("font-size", l_info.title_size + "px")
+        .style("font-size", l_info.title_size)
       ;
       var legend_svgs = legend_rows.append("td")
         .append("svg")
@@ -2210,7 +2210,7 @@ var animint = function (to_select, json_file) {
 	.attr("align", "left") // TODO: right for numbers?
 	.attr("class", "legend_entry_label")
 	.attr("id", function(d){ return d["id"]+"_label"; })
-  	.style("font-size", function(d){ return d["text_size"]+"px"})
+  	.style("font-size", function(d){ return d["text_size"]})
 	.text(function(d){ return d["label"];});
     }
   }

--- a/man/scale_brewer.Rd
+++ b/man/scale_brewer.Rd
@@ -39,13 +39,14 @@ scale_fill_distiller(
 \item{...}{Other arguments passed on to \code{\link{discrete_scale}}
 to control name, limits, breaks, labels and so forth.}
 
-\item{type}{One of seq (sequential), div (diverging) or qual (qualitative)}
+\item{type}{One of "seq" (sequential), "div" (diverging) or "qual"
+(qualitative)}
 
-\item{palette}{If a string, will use that named palette.  If a number, will
+\item{palette}{If a string, will use that named palette. If a number, will
 index into the list of palettes of appropriate \code{type}}
 
 \item{direction}{Sets the order of colours in the scale. If 1, the default,
-colours are as output by \code{\link[RColorBrewer:brewer.pal]{RColorBrewer::brewer.pal()}}. If -1, the
+colours are as output by \code{\link[RColorBrewer:ColorBrewer]{RColorBrewer::brewer.pal()}}. If -1, the
 order of colours is reversed.}
 
 \item{values}{if colours should not be evenly positioned along the gradient

--- a/tests/testthat/test-renderer1-theme-text-size.R
+++ b/tests/testthat/test-renderer1-theme-text-size.R
@@ -9,12 +9,21 @@ viz <- list()
 viz$scatterFacet <- scatterFacet
 info <- animint2HTML(viz)
 
+get_axes_style <- function(html){
+  axis.style.list <- list()
+  for(xy in c("x","y")){
+    xpath <- sprintf(
+      '//g[@class="%saxis axis %saxis_1"]//g[@class="tick major"]//text',
+      xy, xy)
+    axis.style.list[[xy]] <- getStyleValue(html, xpath, "font-size")
+  }
+  axis.style.list
+}
+
 # Axes text size -------------
 test_that("unspecified axis text size default to 11px", {
-  style.value <-
-    getStyleValue(info$html, '//g[@class="xaxis axis xaxis_1"]//g[@class="tick major"]//text', 
-                  "font-size")
-  expect_match(style.value, "11pt")
+  axis.style.list <- get_axes_style(info)
+  expect_match(axis.style.list$x, "11pt")
 })
 
 # rel() only works for axis.text, axis.text.x, axis.text.y
@@ -23,15 +32,10 @@ test_that("specified axis text size with rel()", {
   viz1 <- list()
   viz1$one <- s1
   info1 <- animint2HTML(viz1)
-  axis.x.style.value <-
-    getStyleValue(info1$html, '//g[@class="xaxis axis xaxis_1"]//g[@class="tick major"]//text', 
-                  "font-size")
-  axis.y.style.value <-
-    getStyleValue(info1$html, '//g[@class="yaxis axis yaxis_1"]//g[@class="tick major"]//text', 
-                  "font-size")
+  axis.style.list <- get_axes_style(info1$html)
   # default size for 'text' is 11, so rel(3) * 11 = 33
-  expect_match(axis.x.style.value, "33pt")
-  expect_match(axis.y.style.value, "33pt")
+  expect_match(axis.style.list$x, "33pt")
+  expect_match(axis.style.list$y, "33pt")
 })
 
 test_that("if more than 1 element text size are defined, take the children node", {
@@ -41,14 +45,9 @@ test_that("if more than 1 element text size are defined, take the children node"
   viz2 <- list()
   viz2$one <- s2
   info1 <- animint2HTML(viz2)
-  axis.x.style.value <-
-    getStyleValue(info1$html, '//g[@class="xaxis axis xaxis_1"]//g[@class="tick major"]//text', 
-                  "font-size")
-  axis.y.style.value <-
-    getStyleValue(info1$html, '//g[@class="yaxis axis yaxis_1"]//g[@class="tick major"]//text', 
-                  "font-size")
-  expect_match(axis.x.style.value, "20pt")
-  expect_match(axis.y.style.value, "12pt")
+  axis.style.list <- get_axes_style(info1$html)
+  expect_match(axis.style.list$x, "20pt")
+  expect_match(axis.style.list$y, "12pt")
 })
 
 # legend text size -------------

--- a/tests/testthat/test-renderer1-theme-text-size.R
+++ b/tests/testthat/test-renderer1-theme-text-size.R
@@ -105,3 +105,32 @@ test_that("specified legend title and label text size with rel()", {
   # rel(2.5) * 16 = 24
   expect_match(legend.title.size, "27.5px")
 })
+
+## TDH default theme test, 1 Sep 2022.
+y <- 1:2
+df <- data.frame(y, text=paste("category", y))
+viz <- animint(
+  default=ggplot()+
+    ggtitle("No theme specified")+
+    geom_text(aes(
+      0,y,label=text,color=text),
+      data=df),
+  theme=ggplot()+
+    ggtitle("theme_grey()")+
+    theme_grey()+
+    geom_text(aes(
+      0,y,label=text,color=text),
+      data=df))
+info <- animint2HTML(viz)
+test_that("theme_grey legend entry text size is 16px", {
+  size.list <- list()
+  for(plot.name in names(viz)){
+    selector <- sprintf(
+      '//td[@id="plot_%s_text_variable_category_1_label"]', 
+      plot.name)
+    size.list[[plot.name]] <- getStyleValue(
+      info$html, selector, "font-size")
+  }
+  expect_match(size.list$default, "16px")
+  expect_match(size.list$theme, "16px")
+})

--- a/tests/testthat/test-renderer1-theme-text-size.R
+++ b/tests/testthat/test-renderer1-theme-text-size.R
@@ -21,87 +21,86 @@ get_axes_style <- function(html){
 }
 
 # Axes text size -------------
-test_that("unspecified axis text size default to 11px", {
-  axis.style.list <- get_axes_style(info)
+test_that("unspecified axis text size default to 11pt", {
+  axis.style.list <- get_axes_style(info$html)
   expect_match(axis.style.list$x, "11pt")
 })
 
 # rel() only works for axis.text, axis.text.x, axis.text.y
 test_that("specified axis text size with rel()", {
-  s1 <- scatterFacet + theme(axis.text = element_text(size = rel(3)))
-  viz1 <- list()
-  viz1$one <- s1
-  info1 <- animint2HTML(viz1)
-  axis.style.list <- get_axes_style(info1$html)
+  s <- scatterFacet + theme(axis.text = element_text(size = rel(3)))
+  viz <- list()
+  viz$one <- s
+  info <- animint2HTML(viz)
+  axis.style.list <- get_axes_style(info$html)
   # default size for 'text' is 11, so rel(3) * 11 = 33
   expect_match(axis.style.list$x, "33pt")
   expect_match(axis.style.list$y, "33pt")
 })
 
 test_that("if more than 1 element text size are defined, take the children node", {
-  s2 <- scatterFacet + 
+  s <- scatterFacet + 
         theme(axis.text = element_text(size = 12),
               axis.text.x = element_text(size = 20))
-  viz2 <- list()
-  viz2$one <- s2
-  info1 <- animint2HTML(viz2)
-  axis.style.list <- get_axes_style(info1$html)
+  viz <- list()
+  viz$one <- s
+  info <- animint2HTML(viz)
+  axis.style.list <- get_axes_style(info$html)
   expect_match(axis.style.list$x, "20pt")
   expect_match(axis.style.list$y, "12pt")
 })
 
 # legend text size -------------
-test_that("unspecified legend title and label text size default to 16px", {
+test_that("unspecified legend title default to 11pt, and label text size 8.8pt", {
   title.size <-
     getStyleValue(info$html, '//table[@class="legend"]//tr//th', 
                   "font-size")
   label.size <-
     getStyleValue(info$html, '//table[@class="legend"]//tr[@id="plot_scatterFacet_region_variable_East_Asia_&_Pacific_(all_income_levels)"]//td[@class="legend_entry_label"]', 
                   "font-size")
-  expect_match(title.size, "16pt")
-  expect_match(label.size, "16pt")
+  expect_match(title.size, "11pt")
+  expect_match(label.size, "8.8pt")
 })
 
 test_that("defined legend title text size", {
-  l1 <- scatterFacet + 
+  l <- scatterFacet + 
         theme(legend.title = element_text(size=30))
-  viz1 <- list()
-  viz1$one <- l1
-  info1 <- animint2HTML(viz1)
+  viz <- list()
+  viz$one <- l
+  info <- animint2HTML(viz)
   style.value <-
-    getStyleValue(info1$html, '//table[@class="legend"]//tr//th', 
+    getStyleValue(info$html, '//table[@class="legend"]//tr//th', 
                   "font-size")
   expect_match(style.value, "30pt")
 })
 
 test_that("defined legend label text size", {
-  l1 <- scatterFacet + 
+  l <- scatterFacet + 
         theme(legend.text = element_text(size=10))
-  viz1 <- list()
-  viz1$one <- l1
-  info1 <- animint2HTML(viz1)
+  viz <- list()
+  viz$one <- l
+  info <- animint2HTML(viz)
   style.value <-
-    getStyleValue(info1$html, '//table[@class="legend"]//tr[@id="plot_one_region_variable_Europe_&_Central_Asia_(all_income_levels)"]//td[@id="plot_one_region_variable_Europe_&_Central_Asia_(all_income_levels)_label"]', 
+    getStyleValue(info$html, '//table[@class="legend"]//tr[@id="plot_one_region_variable_Europe_&_Central_Asia_(all_income_levels)"]//td[@id="plot_one_region_variable_Europe_&_Central_Asia_(all_income_levels)_label"]', 
                   "font-size")
   expect_match(style.value, "10pt")
 })
 
 test_that("specified legend title and label text size with rel()", {
-  s1 <- scatterFacet + 
+  s <- scatterFacet + 
         theme(legend.text = element_text(size=rel(2)),
               legend.title = element_text(size=rel(2.5)))
-  viz1 <- list()
-  viz1$one <- s1
-  info1 <- animint2HTML(viz1)
+  viz <- list()
+  viz$one <- s
+  info <- animint2HTML(viz)
   legend.text.size <-
-    getStyleValue(info1$html, '//table[@class="legend"]//tr[@id="plot_one_region_variable_Europe_&_Central_Asia_(all_income_levels)"]//td[@id="plot_one_region_variable_Europe_&_Central_Asia_(all_income_levels)_label"]', 
+    getStyleValue(info$html, '//table[@class="legend"]//tr[@id="plot_one_region_variable_Europe_&_Central_Asia_(all_income_levels)"]//td[@id="plot_one_region_variable_Europe_&_Central_Asia_(all_income_levels)_label"]', 
                   "font-size")
   legend.title.size <-
-    getStyleValue(info1$html, '//table[@class="legend"]//tr//th', 
+    getStyleValue(info$html, '//table[@class="legend"]//tr//th', 
                   "font-size")
   # parent text size for 'legend.text' is 11, so rel(2) * 11 = 22
   expect_match(legend.text.size, "22pt")
-  # rel(2.5) * 16 = 24
   expect_match(legend.title.size, "27.5pt")
 })
 
@@ -126,7 +125,7 @@ viz <- animint(
     theme(legend.text=element_text(size=16))+
     geom_text(aes(
       0,y,label=text,color=text),
-      data=df)+
+      data=df),
   sizePx=ggplot()+
     ggtitle("theme_grey()+theme(legend.text)")+
     theme_grey()+
@@ -148,4 +147,10 @@ test_that("theme_grey legend entry text size is 16px", {
   expect_match(size.list$theme, "8.8pt")
   expect_match(size.list$sizeNum, "16pt")
   expect_match(size.list$sizePx, "16px")
+})
+
+test_that("Warning for invalid character/string input ", {
+  viz <- list(
+    s=scatterFacet + theme(axis.text.x = element_text(size = "12p")))
+  expect_warning(animint2HTML(viz), "axis.text.x is not numeric nor character ending with \'pt\' or \'px\', will be default 11pt")
 })

--- a/tests/testthat/test-renderer1-theme-text-size.R
+++ b/tests/testthat/test-renderer1-theme-text-size.R
@@ -120,6 +120,13 @@ viz <- animint(
     theme_grey()+
     geom_text(aes(
       0,y,label=text,color=text),
+      data=df),
+  size=ggplot()+
+    ggtitle("theme_grey()+theme(legend.text)")+
+    theme_grey()+
+    theme(legend.text=element_text(size=30))+
+    geom_text(aes(
+      0,y,label=text,color=text),
       data=df))
 info <- animint2HTML(viz)
 test_that("theme_grey legend entry text size is 16px", {
@@ -133,4 +140,5 @@ test_that("theme_grey legend entry text size is 16px", {
   }
   expect_match(size.list$default, "16px")
   expect_match(size.list$theme, "16px")
+  expect_match(size.list$size, "30px")
 })

--- a/tests/testthat/test-renderer1-theme-text-size.R
+++ b/tests/testthat/test-renderer1-theme-text-size.R
@@ -14,7 +14,7 @@ test_that("unspecified axis text size default to 11px", {
   style.value <-
     getStyleValue(info$html, '//g[@class="xaxis axis xaxis_1"]//g[@class="tick major"]//text', 
                   "font-size")
-  expect_match(style.value, "11px")
+  expect_match(style.value, "11pt")
 })
 
 # rel() only works for axis.text, axis.text.x, axis.text.y
@@ -30,8 +30,8 @@ test_that("specified axis text size with rel()", {
     getStyleValue(info1$html, '//g[@class="yaxis axis yaxis_1"]//g[@class="tick major"]//text', 
                   "font-size")
   # default size for 'text' is 11, so rel(3) * 11 = 33
-  expect_match(axis.x.style.value, "33px")
-  expect_match(axis.y.style.value, "33px")
+  expect_match(axis.x.style.value, "33pt")
+  expect_match(axis.y.style.value, "33pt")
 })
 
 test_that("if more than 1 element text size are defined, take the children node", {
@@ -47,8 +47,8 @@ test_that("if more than 1 element text size are defined, take the children node"
   axis.y.style.value <-
     getStyleValue(info1$html, '//g[@class="yaxis axis yaxis_1"]//g[@class="tick major"]//text', 
                   "font-size")
-  expect_match(axis.x.style.value, "20px")
-  expect_match(axis.y.style.value, "12px")
+  expect_match(axis.x.style.value, "20pt")
+  expect_match(axis.y.style.value, "12pt")
 })
 
 # legend text size -------------
@@ -59,8 +59,8 @@ test_that("unspecified legend title and label text size default to 16px", {
   label.size <-
     getStyleValue(info$html, '//table[@class="legend"]//tr[@id="plot_scatterFacet_region_variable_East_Asia_&_Pacific_(all_income_levels)"]//td[@class="legend_entry_label"]', 
                   "font-size")
-  expect_match(title.size, "16px")
-  expect_match(label.size, "16px")
+  expect_match(title.size, "16pt")
+  expect_match(label.size, "16pt")
 })
 
 test_that("defined legend title text size", {
@@ -72,7 +72,7 @@ test_that("defined legend title text size", {
   style.value <-
     getStyleValue(info1$html, '//table[@class="legend"]//tr//th', 
                   "font-size")
-  expect_match(style.value, "30px")
+  expect_match(style.value, "30pt")
 })
 
 test_that("defined legend label text size", {
@@ -84,7 +84,7 @@ test_that("defined legend label text size", {
   style.value <-
     getStyleValue(info1$html, '//table[@class="legend"]//tr[@id="plot_one_region_variable_Europe_&_Central_Asia_(all_income_levels)"]//td[@id="plot_one_region_variable_Europe_&_Central_Asia_(all_income_levels)_label"]', 
                   "font-size")
-  expect_match(style.value, "10px")
+  expect_match(style.value, "10pt")
 })
 
 test_that("specified legend title and label text size with rel()", {
@@ -101,9 +101,9 @@ test_that("specified legend title and label text size with rel()", {
     getStyleValue(info1$html, '//table[@class="legend"]//tr//th', 
                   "font-size")
   # parent text size for 'legend.text' is 11, so rel(2) * 11 = 22
-  expect_match(legend.text.size, "22px")
+  expect_match(legend.text.size, "22pt")
   # rel(2.5) * 16 = 24
-  expect_match(legend.title.size, "27.5px")
+  expect_match(legend.title.size, "27.5pt")
 })
 
 ## TDH default theme test, 1 Sep 2022.
@@ -121,10 +121,17 @@ viz <- animint(
     geom_text(aes(
       0,y,label=text,color=text),
       data=df),
-  size=ggplot()+
+  sizeNum=ggplot()+
     ggtitle("theme_grey()+theme(legend.text)")+
     theme_grey()+
-    theme(legend.text=element_text(size=30))+
+    theme(legend.text=element_text(size=16))+
+    geom_text(aes(
+      0,y,label=text,color=text),
+      data=df)+
+  sizePx=ggplot()+
+    ggtitle("theme_grey()+theme(legend.text)")+
+    theme_grey()+
+    theme(legend.text=element_text(size="16px"))+
     geom_text(aes(
       0,y,label=text,color=text),
       data=df))
@@ -138,7 +145,8 @@ test_that("theme_grey legend entry text size is 16px", {
     size.list[[plot.name]] <- getStyleValue(
       info$html, selector, "font-size")
   }
-  expect_match(size.list$default, "16px")
-  expect_match(size.list$theme, "16px")
-  expect_match(size.list$size, "30px")
+  expect_match(size.list$default, "8.8pt")
+  expect_match(size.list$theme, "8.8pt")
+  expect_match(size.list$sizeNum, "16pt")
+  expect_match(size.list$sizePx, "16px")
 })


### PR DESCRIPTION
Hi @Faye-yufan I noticed an unexpected inconsistency while re-building the animint2 manual.
See screenshot below, notice how legend entry sizes are too small in the second plot. I added a test which says both should be 16px. Can you please investigate and fix?
![image](https://user-images.githubusercontent.com/932850/187990563-e3e6b6e8-7dc2-496d-9b16-159fbf985eec.png)
