### PR TITLE
Fix scrolling issue in Firefox

### DIFF
--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -2392,6 +2392,11 @@ var animint = function (to_select, json_file) {
       .attr("class", "table_selector_widgets")
     ;
     var selector_first_tr = selector_table.append("tr");
+    setTimeout(() => {
+      const selector_height = selector_table[0][0].clientHeight;
+      selector_table
+        .style('height', `${selector_height}px`);
+    }, 0);
     selector_first_tr
       .append("th")
       .text("Variable")


### PR DESCRIPTION
fix #90 
Deferred setting of the `selector_table` height to prevent unintended scrollbar behavior. 

Used `setTimeout` with a delay of 0 ms to place the height setting operation on the JavaScript event loop, ensuring it executes after all current tasks and rendering operations are complete.

This change appears to fix an issue where the scrollbar was moving upwards when interacting with Selectize.js elements in Firefox.