### PR TITLE
feat: support subgroup aesthetic in geom_polygon for holes

### DIFF
--- a/R/geom-.r
+++ b/R/geom-.r
@@ -580,6 +580,10 @@ Geom <- gganimintproto("Geom",
     if("group" %in% names(g$aes) && g$geom %in% data.object.geoms){
       g$nest_order <- c(g$nest_order, "group")
     }
+    ## If subgroup is specified for polygon, flag it for JS renderer.
+    if("subgroup" %in% names(g$aes) && g$geom == "polygon"){
+      g$data_has_subgroup <- TRUE
+    }
     ## If user did not specify aes(group), then use group=1.
     if(! "group" %in% names(g$aes)){
       g.data$group <- 1

--- a/R/geom-polygon.r
+++ b/R/geom-polygon.r
@@ -101,7 +101,7 @@ GeomPolygon <- gganimintproto("GeomPolygon", Geom,
   },
 
   default_aes = aes(colour = "NA", fill = "grey20", size = 0.5, linetype = 1,
-    alpha = NA),
+    alpha = NA, subgroup = NULL),
 
   handle_na = function(data, params) {
     data

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -1373,8 +1373,20 @@ var animint = function (to_select, json_file) {
       data_to_bind = kv;
       eActions = function (e) {
         e.attr("d", function (d) {
-          return lineThing(keyed_data[d.value]);
-        })
+          var group_data = keyed_data[d.value];
+          if(g_info.data_has_subgroup){
+            var by_subgroup = d3.nest()
+              .key(function(r){ return r["subgroup"]; })
+              .entries(group_data);
+            return by_subgroup.map(function(sg){
+              return lineThing(sg.values) + "Z";
+            }).join(" ");
+          }
+          return lineThing(group_data);
+        });
+        if(g_info.data_has_subgroup){
+          e.style("fill-rule", "evenodd");
+        }
       };
       eAppend = "path";
     }else{

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -1370,17 +1370,28 @@ var animint = function (to_select, json_file) {
         fill = "none";
         fill_off = "none";
       }
+      // Create d3.geo.path with null projection once (no geographic
+      // reprojection; coordinates are already in pixel space after
+      // applying scales). Used for polygon subgroup holes.
+      var geoPath = d3.geo.path().projection(null);
       data_to_bind = kv;
       eActions = function (e) {
         e.attr("d", function (d) {
           var group_data = keyed_data[d.value];
           if(g_info.data_has_subgroup){
+            // Build a GeoJSON Polygon: first ring is exterior,
+            // subsequent rings are holes (as per GeoJSON spec).
             var by_subgroup = d3.nest()
               .key(function(r){ return r["subgroup"]; })
               .entries(group_data);
-            return by_subgroup.map(function(sg){
-              return lineThing(sg.values) + "Z";
-            }).join(" ");
+            var rings = by_subgroup.map(function(sg){
+              var coords = sg.values.map(function(pt){
+                return [scales.x(pt.x), scales.y(pt.y)];
+              });
+              coords.push(coords[0].slice()); // close ring
+              return coords;
+            });
+            return geoPath({ type: "Polygon", coordinates: rings });
           }
           return lineThing(group_data);
         });

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -1372,8 +1372,8 @@ var animint = function (to_select, json_file) {
       }
       // Create d3.geo.path with null projection once (no geographic
       // reprojection; coordinates are already in pixel space after
-      // applying scales). Used for polygon subgroup holes.
-      var geoPath = d3.geo.path().projection(null);
+      // applying scales). Only needed for polygon subgroup holes.
+      var geoPath = g_info.data_has_subgroup ? d3.geo.path().projection(null) : null;
       data_to_bind = kv;
       eActions = function (e) {
         e.attr("d", function (d) {

--- a/tests/testthat/test-renderer-polygon-subgroup.R
+++ b/tests/testthat/test-renderer-polygon-subgroup.R
@@ -43,15 +43,6 @@ m_simple <- matrix(
     0, 0, 0, 0, 0, 0),
   6, 6, byrow = TRUE)
 
-m_only_hole <- rbind(
-  c(0, 0, 0, 0, 0, 0, 0),
-  c(0, 1, 1, 1, 1, 1, 0),
-  c(0, 1, 0, 0, 0, 1, 0),
-  c(0, 1, 0, 0, 0, 1, 0),
-  c(0, 1, 0, 0, 0, 1, 0),
-  c(0, 1, 1, 1, 1, 1, 0),
-  c(0, 0, 0, 0, 0, 0, 0))
-
 m_no_hole <- rbind(
   c(0, 0, 0, 0, 0, 0, 0),
   c(0, 1, 1, 1, 1, 1, 0),
@@ -70,60 +61,36 @@ m_hole_and_mid <- rbind(
   c(0, 1, 1, 1, 1, 1, 0),
   c(0, 0, 0, 0, 0, 0, 0))
 
-## compiler tests (no browser needed)
+## --- compiler tests (no browser needed) ---
 
-test_that("data_has_subgroup flag is TRUE when subgroup used", {
+test_that("subgroup flag and TSV column present when subgroup used", {
   out <- compile(make_viz(m_simple, subgroup = TRUE))
   expect_true(out$json$geoms$geom1_polygon_poly$data_has_subgroup)
-})
-
-test_that("data_has_subgroup flag is absent when subgroup not used", {
-  out <- compile(make_viz(m_simple, subgroup = FALSE))
-  flag <- out$json$geoms$geom1_polygon_poly$data_has_subgroup
-  expect_false(isTRUE(flag))
-})
-
-test_that("TSV contains subgroup column when subgroup used", {
-  out <- compile(make_viz(m_simple, subgroup = TRUE))
   expect_true("subgroup" %in% names(out$tsv))
-})
-
-test_that("hole polygon TSV has 2 unique subgroup values", {
-  out <- compile(make_viz(m_simple, subgroup = TRUE))
   expect_equal(length(unique(out$tsv$subgroup)), 2)
 })
 
-test_that("no-hole polygon TSV has 1 unique subgroup value", {
-  out <- compile(make_viz(m_no_hole, subgroup = TRUE))
-  expect_equal(length(unique(out$tsv$subgroup)), 1)
+test_that("subgroup flag absent when subgroup not used", {
+  out <- compile(make_viz(m_simple, subgroup = FALSE))
+  expect_false(isTRUE(out$json$geoms$geom1_polygon_poly$data_has_subgroup))
 })
 
-test_that("only_hole case has 2 subgroups in TSV", {
-  out <- compile(make_viz(m_only_hole, subgroup = TRUE))
-  expect_true(out$json$geoms$geom1_polygon_poly$data_has_subgroup)
-  expect_equal(length(unique(out$tsv$subgroup)), 2)
+test_that("no_hole case has 1 subgroup, hole_and_mid has 3", {
+  out_no <- compile(make_viz(m_no_hole, subgroup = TRUE))
+  expect_equal(length(unique(out_no$tsv$subgroup)), 1)
+  out_mid <- compile(make_viz(m_hole_and_mid, subgroup = TRUE))
+  expect_equal(length(unique(out_mid$tsv$subgroup)), 3)
 })
 
-test_that("no_hole case has 1 subgroup in TSV", {
-  out <- compile(make_viz(m_no_hole, subgroup = TRUE))
-  expect_equal(length(unique(out$tsv$subgroup)), 1)
-})
-
-test_that("hole_and_mid case has 3 subgroups in TSV", {
-  out <- compile(make_viz(m_hole_and_mid, subgroup = TRUE))
-  expect_true(out$json$geoms$geom1_polygon_poly$data_has_subgroup)
-  expect_equal(length(unique(out$tsv$subgroup)), 3)
-})
-
-test_that("multiple groups with subgroup: 2 groups in TSV", {
+test_that("multiple groups with subgroup both appear in TSV", {
   res1 <- as.data.table(isoband::isobands(
     (1:ncol(m_simple)) / (ncol(m_simple) + 1),
     (nrow(m_simple):1) / (nrow(m_simple) + 1),
     m_simple, 0.5, 1.5)[[1]])[, grp := "A"]
   res2 <- as.data.table(isoband::isobands(
-    (1:ncol(m_only_hole)) / (ncol(m_only_hole) + 1),
-    (nrow(m_only_hole):1) / (nrow(m_only_hole) + 1),
-    m_only_hole, 0.5, 1.5)[[1]])[, grp := "B"]
+    (1:ncol(m_no_hole)) / (ncol(m_no_hole) + 1),
+    (nrow(m_no_hole):1) / (nrow(m_no_hole) + 1),
+    m_no_hole, 0.5, 1.5)[[1]])[, grp := "B"]
   combined <- rbind(res1, res2)
   viz_multi <- list(
     poly = ggplot() +
@@ -139,16 +106,16 @@ test_that("multiple groups with subgroup: 2 groups in TSV", {
   expect_equal(length(unique(tsv$group)), 2)
 })
 
-## renderer tests (browser required)
-## two groups A and B with clickSelects so clickID works meaningfully
+## --- renderer tests (browser required) ---
+
 res_A <- as.data.table(isoband::isobands(
   (1:ncol(m_simple)) / (ncol(m_simple) + 1),
   (nrow(m_simple):1) / (nrow(m_simple) + 1),
   m_simple, 0.5, 1.5)[[1]])[, grp := "A"]
 res_B <- as.data.table(isoband::isobands(
-  (1:ncol(m_only_hole)) / (ncol(m_only_hole) + 1),
-  (nrow(m_only_hole):1) / (nrow(m_only_hole) + 1),
-  m_only_hole, 0.5, 1.5)[[1]])[, grp := "B"]
+  (1:ncol(m_no_hole)) / (ncol(m_no_hole) + 1),
+  (nrow(m_no_hole):1) / (nrow(m_no_hole) + 1),
+  m_no_hole, 0.5, 1.5)[[1]])[, grp := "B"]
 res_click <- rbind(res_A, res_B)
 
 viz_click <- list(
@@ -163,53 +130,31 @@ viz_click <- list(
 
 info <- animint2HTML(viz_click)
 
-test_that("rendered polygon with subgroup has fill-rule evenodd", {
-  skip_if(!exists("remDr"), "remDr not initialized - run tests_init() first")
+test_that("one path per group with evenodd fill-rule and multiple subpaths", {
   html <- getHTML()
   path_nodes <- getNodeSet(html, "//path[@class='geom']")
-  expect_gt(length(path_nodes), 0)
-  styles <- sapply(path_nodes, xmlGetAttr, "style")
-  expect_true(any(grepl("evenodd", styles)))
-})
-
-test_that("rendered polygon d attribute has 2 closed subpaths", {
-  skip_if(!exists("remDr"), "remDr not initialized - run tests_init() first")
-  html <- getHTML()
-  path_nodes <- getNodeSet(html, "//path[@class='geom']")
-  d_vals <- sapply(path_nodes, xmlGetAttr, "d")
-  z_counts <- sapply(d_vals, function(d) nchar(gsub("[^Z]", "", d)))
-  expect_true(any(z_counts >= 2))
-})
-
-test_that("hole subgroup merged into one path per group not two separate polygons", {
-  skip_if(!exists("remDr"), "remDr not initialized - run tests_init() first")
-  html <- getHTML()
-  path_nodes <- getNodeSet(html, "//path[@class='geom']")
-  ## 2 groups A and B => 2 path elements (one per group), not 4
+  ## 2 groups A and B => 2 path elements (not 4)
   expect_equal(length(path_nodes), 2)
+  ## fill-rule must be evenodd
+  styles <- sapply(path_nodes, xmlGetAttr, "style")
+  expect_true(any(grepl("evenodd", styles)))
+  ## group A (with hole) must have multiple closed subpaths (M commands)
+  d_vals <- sapply(path_nodes, xmlGetAttr, "d")
+  m_counts <- sapply(d_vals, function(d) length(gregexpr("M", d)[[1]]))
+  expect_true(any(m_counts >= 2))
 })
 
-test_that("clickID on group A polygon deselects it and leaves group B visible", {
-  skip_if(!exists("remDr"), "remDr not initialized - run tests_init() first")
-  ## click group A to deselect it
+test_that("clickSelects works with subgroup polygons", {
+  ## click group A to deselect
   clickID("poly_A")
   Sys.sleep(1)
   html_after <- getHTML()
   path_nodes <- getNodeSet(html_after, "//path[@class='geom']")
-  ## group B path should still exist
   expect_gt(length(path_nodes), 0)
-  ## all remaining paths must still use evenodd fill rule
-  styles <- sapply(path_nodes, xmlGetAttr, "style")
-  expect_true(any(grepl("evenodd", styles)))
-})
-
-test_that("clickID on group A again reselects it restoring both polygons", {
-  skip_if(!exists("remDr"), "remDr not initialized - run tests_init() first")
+  ## click again to reselect
   clickID("poly_A")
   Sys.sleep(1)
-  html_after <- getHTML()
-  path_nodes <- getNodeSet(html_after, "//path[@class='geom']")
-  expect_gte(length(path_nodes), 1)
-  styles <- sapply(path_nodes, xmlGetAttr, "style")
-  expect_true(any(grepl("evenodd", styles)))
+  html_restored <- getHTML()
+  path_nodes_restored <- getNodeSet(html_restored, "//path[@class='geom']")
+  expect_gte(length(path_nodes_restored), 1)
 })

--- a/tests/testthat/test-renderer-polygon-subgroup.R
+++ b/tests/testthat/test-renderer-polygon-subgroup.R
@@ -34,7 +34,6 @@ compile <- function(viz) {
   )
 }
 
-# matrices from issue #252
 m_simple <- matrix(
   c(0, 0, 0, 0, 0, 0,
     0, 1, 1, 1, 1, 0,
@@ -71,7 +70,7 @@ m_hole_and_mid <- rbind(
   c(0, 1, 1, 1, 1, 1, 0),
   c(0, 0, 0, 0, 0, 0, 0))
 
-viz <- make_viz(m_simple, subgroup = TRUE)
+## compiler tests (no browser needed)
 
 test_that("data_has_subgroup flag is TRUE when subgroup used", {
   out <- compile(make_viz(m_simple, subgroup = TRUE))
@@ -121,12 +120,10 @@ test_that("multiple groups with subgroup: 2 groups in TSV", {
     (1:ncol(m_simple)) / (ncol(m_simple) + 1),
     (nrow(m_simple):1) / (nrow(m_simple) + 1),
     m_simple, 0.5, 1.5)[[1]])[, grp := "A"]
-
   res2 <- as.data.table(isoband::isobands(
     (1:ncol(m_only_hole)) / (ncol(m_only_hole) + 1),
     (nrow(m_only_hole):1) / (nrow(m_only_hole) + 1),
     m_only_hole, 0.5, 1.5)[[1]])[, grp := "B"]
-
   combined <- rbind(res1, res2)
   viz_multi <- list(
     poly = ggplot() +
@@ -142,22 +139,77 @@ test_that("multiple groups with subgroup: 2 groups in TSV", {
   expect_equal(length(unique(tsv$group)), 2)
 })
 
+## renderer tests (browser required)
+## two groups A and B with clickSelects so clickID works meaningfully
+res_A <- as.data.table(isoband::isobands(
+  (1:ncol(m_simple)) / (ncol(m_simple) + 1),
+  (nrow(m_simple):1) / (nrow(m_simple) + 1),
+  m_simple, 0.5, 1.5)[[1]])[, grp := "A"]
+res_B <- as.data.table(isoband::isobands(
+  (1:ncol(m_only_hole)) / (ncol(m_only_hole) + 1),
+  (nrow(m_only_hole):1) / (nrow(m_only_hole) + 1),
+  m_only_hole, 0.5, 1.5)[[1]])[, grp := "B"]
+res_click <- rbind(res_A, res_B)
+
+viz_click <- list(
+  poly = ggplot() +
+    geom_polygon(
+      aes(x, y, group = grp, subgroup = id, fill = grp,
+          id = paste0("poly_", grp)),
+      clickSelects = "grp",
+      data = res_click
+    )
+)
+
+info <- animint2HTML(viz_click)
+
 test_that("rendered polygon with subgroup has fill-rule evenodd", {
   skip_if(!exists("remDr"), "remDr not initialized - run tests_init() first")
-  res <- animint2HTML(viz)
-  html <- res$html
-  path_nodes <- XML::getNodeSet(html, "//path[contains(@class,'geom')]")
+  html <- getHTML()
+  path_nodes <- getNodeSet(html, "//path[@class='geom']")
   expect_gt(length(path_nodes), 0)
-  styles <- sapply(path_nodes, XML::xmlGetAttr, "style")
+  styles <- sapply(path_nodes, xmlGetAttr, "style")
   expect_true(any(grepl("evenodd", styles)))
 })
 
-test_that("rendered polygon with subgroup d attribute has 2 closed subpaths", {
+test_that("rendered polygon d attribute has 2 closed subpaths", {
   skip_if(!exists("remDr"), "remDr not initialized - run tests_init() first")
-  res <- animint2HTML(viz)
-  html <- res$html
-  path_nodes <- XML::getNodeSet(html, "//path[contains(@class,'geom')]")
-  d_vals <- sapply(path_nodes, XML::xmlGetAttr, "d")
-  z_counts <- sapply(d_vals, function(d) length(gregexpr("Z", d)[[1]]))
+  html <- getHTML()
+  path_nodes <- getNodeSet(html, "//path[@class='geom']")
+  d_vals <- sapply(path_nodes, xmlGetAttr, "d")
+  z_counts <- sapply(d_vals, function(d) nchar(gsub("[^Z]", "", d)))
   expect_true(any(z_counts >= 2))
+})
+
+test_that("hole subgroup merged into one path per group not two separate polygons", {
+  skip_if(!exists("remDr"), "remDr not initialized - run tests_init() first")
+  html <- getHTML()
+  path_nodes <- getNodeSet(html, "//path[@class='geom']")
+  ## 2 groups A and B => 2 path elements (one per group), not 4
+  expect_equal(length(path_nodes), 2)
+})
+
+test_that("clickID on group A polygon deselects it and leaves group B visible", {
+  skip_if(!exists("remDr"), "remDr not initialized - run tests_init() first")
+  ## click group A to deselect it
+  clickID("poly_A")
+  Sys.sleep(1)
+  html_after <- getHTML()
+  path_nodes <- getNodeSet(html_after, "//path[@class='geom']")
+  ## group B path should still exist
+  expect_gt(length(path_nodes), 0)
+  ## all remaining paths must still use evenodd fill rule
+  styles <- sapply(path_nodes, xmlGetAttr, "style")
+  expect_true(any(grepl("evenodd", styles)))
+})
+
+test_that("clickID on group A again reselects it restoring both polygons", {
+  skip_if(!exists("remDr"), "remDr not initialized - run tests_init() first")
+  clickID("poly_A")
+  Sys.sleep(1)
+  html_after <- getHTML()
+  path_nodes <- getNodeSet(html_after, "//path[@class='geom']")
+  expect_gte(length(path_nodes), 1)
+  styles <- sapply(path_nodes, xmlGetAttr, "style")
+  expect_true(any(grepl("evenodd", styles)))
 })

--- a/tests/testthat/test-renderer-polygon-subgroup.R
+++ b/tests/testthat/test-renderer-polygon-subgroup.R
@@ -1,0 +1,163 @@
+acontext("polygon subgroup holes")
+library(animint2)
+library(isoband)
+library(data.table)
+library(jsonlite)
+
+make_viz <- function(m, subgroup = TRUE) {
+  res <- as.data.table(
+    isoband::isobands(
+      (1:ncol(m)) / (ncol(m) + 1),
+      (nrow(m):1) / (nrow(m) + 1),
+      m, 0.5, 1.5
+    )[[1]]
+  )
+  if (subgroup) {
+    list(poly = ggplot() +
+      geom_polygon(aes(x, y, group = 1, subgroup = id), data = res))
+  } else {
+    list(poly = ggplot() +
+      geom_polygon(aes(x, y, group = id), data = res))
+  }
+}
+
+compile <- function(viz) {
+  out_dir <- tempfile()
+  animint2dir(viz, out.dir = out_dir, open.browser = FALSE)
+  list(
+    json = jsonlite::fromJSON(file.path(out_dir, "plot.json")),
+    tsv  = read.table(
+      file.path(out_dir, "geom1_polygon_poly_chunk1.tsv"),
+      header = TRUE, sep = "\t"
+    ),
+    dir = out_dir
+  )
+}
+
+# matrices from issue #252
+m_simple <- matrix(
+  c(0, 0, 0, 0, 0, 0,
+    0, 1, 1, 1, 1, 0,
+    0, 1, 0, 0, 1, 0,
+    0, 1, 0, 0, 1, 0,
+    0, 1, 1, 1, 1, 0,
+    0, 0, 0, 0, 0, 0),
+  6, 6, byrow = TRUE)
+
+m_only_hole <- rbind(
+  c(0, 0, 0, 0, 0, 0, 0),
+  c(0, 1, 1, 1, 1, 1, 0),
+  c(0, 1, 0, 0, 0, 1, 0),
+  c(0, 1, 0, 0, 0, 1, 0),
+  c(0, 1, 0, 0, 0, 1, 0),
+  c(0, 1, 1, 1, 1, 1, 0),
+  c(0, 0, 0, 0, 0, 0, 0))
+
+m_no_hole <- rbind(
+  c(0, 0, 0, 0, 0, 0, 0),
+  c(0, 1, 1, 1, 1, 1, 0),
+  c(0, 1, 1, 1, 1, 1, 0),
+  c(0, 1, 1, 1, 1, 1, 0),
+  c(0, 1, 1, 1, 1, 1, 0),
+  c(0, 1, 1, 1, 1, 1, 0),
+  c(0, 0, 0, 0, 0, 0, 0))
+
+m_hole_and_mid <- rbind(
+  c(0, 0, 0, 0, 0, 0, 0),
+  c(0, 1, 1, 1, 1, 1, 0),
+  c(0, 1, 0, 0, 0, 1, 0),
+  c(0, 1, 0, 1, 0, 1, 0),
+  c(0, 1, 0, 0, 0, 1, 0),
+  c(0, 1, 1, 1, 1, 1, 0),
+  c(0, 0, 0, 0, 0, 0, 0))
+
+viz <- make_viz(m_simple, subgroup = TRUE)
+
+test_that("data_has_subgroup flag is TRUE when subgroup used", {
+  out <- compile(make_viz(m_simple, subgroup = TRUE))
+  expect_true(out$json$geoms$geom1_polygon_poly$data_has_subgroup)
+})
+
+test_that("data_has_subgroup flag is absent when subgroup not used", {
+  out <- compile(make_viz(m_simple, subgroup = FALSE))
+  flag <- out$json$geoms$geom1_polygon_poly$data_has_subgroup
+  expect_false(isTRUE(flag))
+})
+
+test_that("TSV contains subgroup column when subgroup used", {
+  out <- compile(make_viz(m_simple, subgroup = TRUE))
+  expect_true("subgroup" %in% names(out$tsv))
+})
+
+test_that("hole polygon TSV has 2 unique subgroup values", {
+  out <- compile(make_viz(m_simple, subgroup = TRUE))
+  expect_equal(length(unique(out$tsv$subgroup)), 2)
+})
+
+test_that("no-hole polygon TSV has 1 unique subgroup value", {
+  out <- compile(make_viz(m_no_hole, subgroup = TRUE))
+  expect_equal(length(unique(out$tsv$subgroup)), 1)
+})
+
+test_that("only_hole case has 2 subgroups in TSV", {
+  out <- compile(make_viz(m_only_hole, subgroup = TRUE))
+  expect_true(out$json$geoms$geom1_polygon_poly$data_has_subgroup)
+  expect_equal(length(unique(out$tsv$subgroup)), 2)
+})
+
+test_that("no_hole case has 1 subgroup in TSV", {
+  out <- compile(make_viz(m_no_hole, subgroup = TRUE))
+  expect_equal(length(unique(out$tsv$subgroup)), 1)
+})
+
+test_that("hole_and_mid case has 3 subgroups in TSV", {
+  out <- compile(make_viz(m_hole_and_mid, subgroup = TRUE))
+  expect_true(out$json$geoms$geom1_polygon_poly$data_has_subgroup)
+  expect_equal(length(unique(out$tsv$subgroup)), 3)
+})
+
+test_that("multiple groups with subgroup: 2 groups in TSV", {
+  res1 <- as.data.table(isoband::isobands(
+    (1:ncol(m_simple)) / (ncol(m_simple) + 1),
+    (nrow(m_simple):1) / (nrow(m_simple) + 1),
+    m_simple, 0.5, 1.5)[[1]])[, grp := "A"]
+
+  res2 <- as.data.table(isoband::isobands(
+    (1:ncol(m_only_hole)) / (ncol(m_only_hole) + 1),
+    (nrow(m_only_hole):1) / (nrow(m_only_hole) + 1),
+    m_only_hole, 0.5, 1.5)[[1]])[, grp := "B"]
+
+  combined <- rbind(res1, res2)
+  viz_multi <- list(
+    poly = ggplot() +
+      geom_polygon(aes(x, y, group = grp, subgroup = id), data = combined)
+  )
+  out_dir <- tempfile()
+  animint2dir(viz_multi, out.dir = out_dir, open.browser = FALSE)
+  tsv <- read.table(
+    file.path(out_dir, "geom1_polygon_poly_chunk1.tsv"),
+    header = TRUE, sep = "\t"
+  )
+  expect_true("subgroup" %in% names(tsv))
+  expect_equal(length(unique(tsv$group)), 2)
+})
+
+test_that("rendered polygon with subgroup has fill-rule evenodd", {
+  skip_if(!exists("remDr"), "remDr not initialized - run tests_init() first")
+  res <- animint2HTML(viz)
+  html <- res$html
+  path_nodes <- XML::getNodeSet(html, "//path[contains(@class,'geom')]")
+  expect_gt(length(path_nodes), 0)
+  styles <- sapply(path_nodes, XML::xmlGetAttr, "style")
+  expect_true(any(grepl("evenodd", styles)))
+})
+
+test_that("rendered polygon with subgroup d attribute has 2 closed subpaths", {
+  skip_if(!exists("remDr"), "remDr not initialized - run tests_init() first")
+  res <- animint2HTML(viz)
+  html <- res$html
+  path_nodes <- XML::getNodeSet(html, "//path[contains(@class,'geom')]")
+  d_vals <- sapply(path_nodes, XML::xmlGetAttr, "d")
+  z_counts <- sapply(d_vals, function(d) length(gregexpr("Z", d)[[1]]))
+  expect_true(any(z_counts >= 2))
+})


### PR DESCRIPTION
## Problem

working on #252

When using `isoband::isobands()` to generate contour data for shapes with holes (like a donut/ring), animint2 was rendering two separate filled polygons instead of one polygon with a transparent hole. This made it impossible to correctly visualize Hi-C genomic cluster contours and similar real-world data.

**Before (bug):**
<img width="932" height="688" alt="Screenshot 2026-03-02 042021" src="https://github.com/user-attachments/assets/1a3514b2-7ec4-4403-8fd9-88a7c8b5d11b" />


The root cause was a two-layer problem:
1. **R compiler:** The `subgroup` aesthetic (added in ggplot2 3.2.0) was completely absent from `GeomPolygon` — not in `default_aes`, not detected by the compiler
2. **JS renderer:** No `fill-rule` logic existed — SVG requires `fill-rule: evenodd` to render polygon holes correctly

---

## Solution

### `R/geom-polygon.r`
Added `subgroup = NULL` to `default_aes` so `GeomPolygon` recognizes the aesthetic.

### `R/geom-.r`
In `export_animint`, added detection of `subgroup` aesthetic on polygon geoms and sets `g$data_has_subgroup <- TRUE`. This flag gets serialized into `plot.json` and read by the browser renderer.

### `inst/htmljs/animint.js`
Modified `eActions` for grouped geoms to:
- Detect `g_info.data_has_subgroup`
- Group points by `"subgroup"` column using `d3.nest()`
- Build separate SVG subpaths per subgroup, each closed with `"Z"`
- Apply `fill-rule: evenodd` — standard SVG technique for holes

**Key finding:** `ggplot_build` renames data columns to the aesthetic name, so the TSV column is always `"subgroup"` regardless of the original variable name in the data.

**After (fix):**
<img width="787" height="646" alt="Screenshot 2026-03-02 043049" src="https://github.com/user-attachments/assets/5f8a20bb-c572-48d6-95ba-e572d915716b" />


---

## Reproducer
```r
library(animint2)
library(isoband)
library(data.table)

m <- matrix(c(0,0,0,0,0,0,
              0,1,1,1,1,0,
              0,1,0,0,1,0,
              0,1,0,0,1,0,
              0,1,1,1,1,0,
              0,0,0,0,0,0), 6, 6, byrow=TRUE)

res <- isoband::isobands(
  (1:ncol(m))/(ncol(m)+1),
  (nrow(m):1)/(nrow(m)+1),
  m, 0.5, 1.5)[[1]]

animint2dir(list(
  poly = ggplot() +
    geom_polygon(aes(x, y, group=1, subgroup=id),
                 data=as.data.table(res))
))
```

---
@tdhock  Could you please take a look

## TODO
- [ ] Add testthat test with `clickID`/`mouseMove`
- [ ] Add vignette example
- [ ] Test edge case: more than 2 subgroups