### PR TITLE
animint.js: remove unnecessary Selectors.hasOwnProperty checks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: animint2
 Title: Animated Interactive Grammar of Graphics
-Version: 2026.2.28
+Version: 2026.3.2
 URL: https://animint.github.io/animint2
 BugReports: https://github.com/animint/animint2/issues
 Authors@R: c(
@@ -64,7 +64,7 @@ Authors@R: c(
      comment="Animint2 GSoC 2025"),
     person("Gaurav", "Chaudhary",
      role="ctb",
-     comment="Remove unused css.file parameter; fix issue #233 selector values; fix issue #273 update_axes tick font-size; fix issue #276 update_axes transition duration"))
+     comment="Remove unused css.file parameter; fix issue #233 selector values; fix issue #273 update_axes tick font-size; fix issue #276 update_axes transition duration; #278 Removed unnecessary Selectors.hasOwnProperty checks in animint.js"))
 Description: Functions are provided for defining animated,
  interactive data visualizations in R code, and rendering
  on a web page. The 2018 Journal of Computational and 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,7 +64,7 @@ Authors@R: c(
      comment="Animint2 GSoC 2025"),
     person("Gaurav", "Chaudhary",
      role="ctb",
-     comment="Remove unused css.file parameter; fix issue #233 selector values; fix issue #273 update_axes tick font-size; fix issue #276 update_axes transition duration"),
+     comment="Remove unused css.file parameter; fix issue #233 selector values; fix issue #273 update_axes tick font-size; fix issue #276 update_axes transition duration; #278 Removed unnecessary Selectors.hasOwnProperty checks in animint.js"),
     person("Nandani", "Aggarwal",
      role="ctb",
      comment="Removed geom_dotplot and replaced with error"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,7 +64,7 @@ Authors@R: c(
      comment="Animint2 GSoC 2025"),
     person("Gaurav", "Chaudhary",
      role="ctb",
-     comment="Remove unused css.file parameter; fix issue #233 selector values; fix issue #273 update_axes tick font-size; fix issue #276 update_axes transition duration; #278 Removed unnecessary Selectors.hasOwnProperty checks in animint.js"),
+     comment="GSOC 2026"),
     person("Nandani", "Aggarwal",
      role="ctb",
      comment="Removed geom_dotplot and replaced with error"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# Changes in version 2026.3.2 (PR#285)
+# Changes in version 2026.3.2 (PR#306)
 
 - `animint.js`: Remove unnecessary `Selectors.hasOwnProperty` checks (issue #278).
   Selector names are always valid when accessed, so membership checks are redundant.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# Changes in version 2026.3.2 (PR#285)
+
+- `animint.js`: Remove unnecessary `Selectors.hasOwnProperty` checks (issue #278).
+  Selector names are always valid when accessed, so membership checks are redundant.
+
 # Changes in version 2025.12.4 (PR#277)
 
 - `update_axes`: Fix issue #276 where transition duration was hardcoded to 1000ms. Now it respects the selector's duration.

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,11 @@
 
 - `geom_dotplot()` has been removed. Use `geom_point()` instead for interactive visualizations. (Fixed #289)
 
+# Changes in version 2026.3.2 (PR#306)
+
+- `animint.js`: Remove unnecessary `Selectors.hasOwnProperty` checks (issue #278).
+  Selector names are always valid when accessed, so membership checks are redundant.
+
 # Changes in version 2025.12.4 (PR#277)
 
 - `update_axes`: Fix issue #276 where transition duration was hardcoded to 1000ms. Now it respects the selector's duration.

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,8 +8,7 @@
 
 # Changes in version 2026.3.2 (PR#306)
 
-- `animint.js`: Remove unnecessary `Selectors.hasOwnProperty` checks (issue #278).
-  Selector names are always valid when accessed, so membership checks are redundant.
+- `animint.js`: Remove redundant `Selectors.hasOwnProperty` checks and use a shared `selector_has_duration()` helper (issue #278, PR#306).
 
 # Changes in version 2025.12.4 (PR#277)
 

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -1566,7 +1566,10 @@ var animint = function (to_select, json_file) {
           eAppend = "g";
           eActions = function(groups) {
             // Handle transitions seperately due to unique structure of geom_label_aligned
-            var transitionDuration = +Selectors[selector_name].duration || 0;
+            var transitionDuration = 0;
+            if (selector_name) {
+              transitionDuration = +Selectors[selector_name].duration || 0;
+            }
             groups.each(function(d) {
               var group = d3.select(this);
               // Select existing elements (if any)
@@ -1860,8 +1863,10 @@ var animint = function (to_select, json_file) {
           positionTooltip(tooltip, tooltip.html());
         });
     }
-    var milliseconds = Selectors[selector_name].duration;
-    elements = elements.transition().duration(milliseconds);
+    if(selector_name){
+      var milliseconds = Selectors[selector_name].duration;
+      elements = elements.transition().duration(milliseconds);
+    }
     if(g_info.aes.hasOwnProperty("id")){
       elements.attr("id", get_attr("id"));
     }

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -1567,7 +1567,7 @@ var animint = function (to_select, json_file) {
           eActions = function(groups) {
             // Handle transitions seperately due to unique structure of geom_label_aligned
             var transitionDuration = 0;
-            if (selector_name) {
+            if(selector_name && Selectors[selector_name].hasOwnProperty("duration")){
               transitionDuration = +Selectors[selector_name].duration || 0;
             }
             groups.each(function(d) {
@@ -1863,7 +1863,7 @@ var animint = function (to_select, json_file) {
           positionTooltip(tooltip, tooltip.html());
         });
     }
-    if(selector_name){
+    if(selector_name && Selectors[selector_name].hasOwnProperty("duration")){
       var milliseconds = Selectors[selector_name].duration;
       elements = elements.transition().duration(milliseconds);
     }

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -2011,7 +2011,7 @@ var animint = function (to_select, json_file) {
     // update existing axis
     var xyaxis_sel = element.select("#"+viz_id+"_"+p_name).select("."+axes+"axis_"+panel_i);
     var milliseconds = 0;
-    if(Selectors[v_name].hasOwnProperty("duration")){
+    if(v_name && Selectors.hasOwnProperty(v_name) && Selectors[v_name].hasOwnProperty("duration")){
       milliseconds = Selectors[v_name].duration;
     }
     var xyaxis_g = xyaxis_sel

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -1567,7 +1567,7 @@ var animint = function (to_select, json_file) {
           eActions = function(groups) {
             // Handle transitions seperately due to unique structure of geom_label_aligned
             var transitionDuration = 0;
-            if (Selectors.hasOwnProperty(selector_name)) {
+            if (selector_name) {
               transitionDuration = +Selectors[selector_name].duration || 0;
             }
             groups.each(function(d) {
@@ -1863,7 +1863,7 @@ var animint = function (to_select, json_file) {
           positionTooltip(tooltip, tooltip.html());
         });
     }
-    if(Selectors.hasOwnProperty(selector_name)){
+    if(selector_name){
       var milliseconds = Selectors[selector_name].duration;
       elements = elements.transition().duration(milliseconds);
     }
@@ -2011,7 +2011,7 @@ var animint = function (to_select, json_file) {
     // update existing axis
     var xyaxis_sel = element.select("#"+viz_id+"_"+p_name).select("."+axes+"axis_"+panel_i);
     var milliseconds = 0;
-    if(v_name && Selectors.hasOwnProperty(v_name) && Selectors[v_name].hasOwnProperty("duration")){
+    if(v_name && Selectors[v_name].hasOwnProperty("duration")){
       milliseconds = Selectors[v_name].duration;
     }
     var xyaxis_g = xyaxis_sel
@@ -2088,9 +2088,6 @@ var animint = function (to_select, json_file) {
   }
 
   var update_selector = function (v_name, value) {
-    if(!Selectors.hasOwnProperty(v_name)){
-      return;
-    }
     value = value + "";
     var s_info = Selectors[v_name];
     if(s_info.type == "single"){

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -1566,10 +1566,7 @@ var animint = function (to_select, json_file) {
           eAppend = "g";
           eActions = function(groups) {
             // Handle transitions seperately due to unique structure of geom_label_aligned
-            var transitionDuration = 0;
-            if (selector_name) {
-              transitionDuration = +Selectors[selector_name].duration || 0;
-            }
+            var transitionDuration = +Selectors[selector_name].duration || 0;
             groups.each(function(d) {
               var group = d3.select(this);
               // Select existing elements (if any)
@@ -1863,10 +1860,8 @@ var animint = function (to_select, json_file) {
           positionTooltip(tooltip, tooltip.html());
         });
     }
-    if(selector_name){
-      var milliseconds = Selectors[selector_name].duration;
-      elements = elements.transition().duration(milliseconds);
-    }
+    var milliseconds = Selectors[selector_name].duration;
+    elements = elements.transition().duration(milliseconds);
     if(g_info.aes.hasOwnProperty("id")){
       elements.attr("id", get_attr("id"));
     }
@@ -2011,7 +2006,7 @@ var animint = function (to_select, json_file) {
     // update existing axis
     var xyaxis_sel = element.select("#"+viz_id+"_"+p_name).select("."+axes+"axis_"+panel_i);
     var milliseconds = 0;
-    if(v_name && Selectors[v_name].hasOwnProperty("duration")){
+    if(Selectors[v_name].hasOwnProperty("duration")){
       milliseconds = Selectors[v_name].duration;
     }
     var xyaxis_g = xyaxis_sel

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -1567,7 +1567,7 @@ var animint = function (to_select, json_file) {
           eActions = function(groups) {
             // Handle transitions seperately due to unique structure of geom_label_aligned
             var transitionDuration = 0;
-            if(selector_name && Selectors[selector_name].hasOwnProperty("duration")){
+            if(selector_name && Selectors.hasOwnProperty(selector_name) && Selectors[selector_name].hasOwnProperty("duration")){
               transitionDuration = +Selectors[selector_name].duration || 0;
             }
             groups.each(function(d) {
@@ -1863,7 +1863,7 @@ var animint = function (to_select, json_file) {
           positionTooltip(tooltip, tooltip.html());
         });
     }
-    if(selector_name && Selectors[selector_name].hasOwnProperty("duration")){
+    if(selector_name && Selectors.hasOwnProperty(selector_name) && Selectors[selector_name].hasOwnProperty("duration")){
       var milliseconds = Selectors[selector_name].duration;
       elements = elements.transition().duration(milliseconds);
     }

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -1641,7 +1641,10 @@ var animint = function (to_select, json_file) {
           eAppend = "g";
           eActions = function(groups) {
             // Handle transitions seperately due to unique structure of geom_label_aligned
-            var transitionDuration = +Selectors[selector_name].duration || 0;
+            var transitionDuration = 0;
+            if (selector_name) {
+              transitionDuration = +Selectors[selector_name].duration || 0;
+            }
             groups.each(function(d) {
               var group = d3.select(this);
               // Select existing elements (if any)
@@ -1935,8 +1938,10 @@ var animint = function (to_select, json_file) {
           positionTooltip(tooltip, tooltip.html());
         });
     }
-    var milliseconds = Selectors[selector_name].duration;
-    elements = elements.transition().duration(milliseconds);
+    if(selector_name){
+      var milliseconds = Selectors[selector_name].duration;
+      elements = elements.transition().duration(milliseconds);
+    }
     if(g_info.aes.hasOwnProperty("id")){
       elements.attr("id", get_attr("id"));
     }

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -101,10 +101,10 @@ var animint = function (to_select, json_file) {
     return safe_name(selector_name) + "_variable";
   }
 
+  // selector_name can be null for geoms without a selector (initial render via update_geom(g, null)).
   function selector_has_duration(name) {
-    return !!(name &&
-      Selectors.hasOwnProperty(name) &&
-      Selectors[name].hasOwnProperty("duration"));
+    return name &&
+      Selectors[name].hasOwnProperty("duration");
   }
 
   function is_interactive_aes(v_name){

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -1642,7 +1642,7 @@ var animint = function (to_select, json_file) {
           eActions = function(groups) {
             // Handle transitions seperately due to unique structure of geom_label_aligned
             var transitionDuration = 0;
-            if (Selectors.hasOwnProperty(selector_name)) {
+            if (selector_name) {
               transitionDuration = +Selectors[selector_name].duration || 0;
             }
             groups.each(function(d) {
@@ -1938,7 +1938,7 @@ var animint = function (to_select, json_file) {
           positionTooltip(tooltip, tooltip.html());
         });
     }
-    if(Selectors.hasOwnProperty(selector_name)){
+    if(selector_name){
       var milliseconds = Selectors[selector_name].duration;
       elements = elements.transition().duration(milliseconds);
     }
@@ -2086,7 +2086,7 @@ var animint = function (to_select, json_file) {
     // update existing axis
     var xyaxis_sel = element.select("#"+viz_id+"_"+p_name).select("."+axes+"axis_"+panel_i);
     var milliseconds = 0;
-    if(v_name && Selectors.hasOwnProperty(v_name) && Selectors[v_name].hasOwnProperty("duration")){
+    if(v_name && Selectors[v_name].hasOwnProperty("duration")){
       milliseconds = Selectors[v_name].duration;
     }
     var xyaxis_g = xyaxis_sel
@@ -2163,9 +2163,6 @@ var animint = function (to_select, json_file) {
   }
 
   var update_selector = function (v_name, value) {
-    if(!Selectors.hasOwnProperty(v_name)){
-      return;
-    }
     value = value + "";
     var s_info = Selectors[v_name];
     if(s_info.type == "single"){

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -1642,7 +1642,7 @@ var animint = function (to_select, json_file) {
           eActions = function(groups) {
             // Handle transitions seperately due to unique structure of geom_label_aligned
             var transitionDuration = 0;
-            if(selector_name && Selectors[selector_name].hasOwnProperty("duration")){
+            if(selector_name && Selectors.hasOwnProperty(selector_name) && Selectors[selector_name].hasOwnProperty("duration")){
               transitionDuration = +Selectors[selector_name].duration || 0;
             }
             groups.each(function(d) {
@@ -1938,7 +1938,7 @@ var animint = function (to_select, json_file) {
           positionTooltip(tooltip, tooltip.html());
         });
     }
-    if(selector_name && Selectors[selector_name].hasOwnProperty("duration")){
+    if(selector_name && Selectors.hasOwnProperty(selector_name) && Selectors[selector_name].hasOwnProperty("duration")){
       var milliseconds = Selectors[selector_name].duration;
       elements = elements.transition().duration(milliseconds);
     }

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -101,6 +101,12 @@ var animint = function (to_select, json_file) {
     return safe_name(selector_name) + "_variable";
   }
 
+  function selector_has_duration(name) {
+    return !!(name &&
+      Selectors.hasOwnProperty(name) &&
+      Selectors[name].hasOwnProperty("duration"));
+  }
+
   function is_interactive_aes(v_name){
     if(v_name.indexOf("clickSelects") > -1){
       return true;
@@ -1642,7 +1648,7 @@ var animint = function (to_select, json_file) {
           eActions = function(groups) {
             // Handle transitions seperately due to unique structure of geom_label_aligned
             var transitionDuration = 0;
-            if(selector_name && Selectors.hasOwnProperty(selector_name) && Selectors[selector_name].hasOwnProperty("duration")){
+            if(selector_has_duration(selector_name)){
               transitionDuration = +Selectors[selector_name].duration || 0;
             }
             groups.each(function(d) {
@@ -1938,7 +1944,7 @@ var animint = function (to_select, json_file) {
           positionTooltip(tooltip, tooltip.html());
         });
     }
-    if(selector_name && Selectors.hasOwnProperty(selector_name) && Selectors[selector_name].hasOwnProperty("duration")){
+    if(selector_has_duration(selector_name)){
       var milliseconds = Selectors[selector_name].duration;
       elements = elements.transition().duration(milliseconds);
     }
@@ -2086,7 +2092,7 @@ var animint = function (to_select, json_file) {
     // update existing axis
     var xyaxis_sel = element.select("#"+viz_id+"_"+p_name).select("."+axes+"axis_"+panel_i);
     var milliseconds = 0;
-    if(v_name && Selectors.hasOwnProperty(v_name) && Selectors[v_name].hasOwnProperty("duration")){
+    if(selector_has_duration(v_name)){
       milliseconds = Selectors[v_name].duration;
     }
     var xyaxis_g = xyaxis_sel

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -1641,10 +1641,7 @@ var animint = function (to_select, json_file) {
           eAppend = "g";
           eActions = function(groups) {
             // Handle transitions seperately due to unique structure of geom_label_aligned
-            var transitionDuration = 0;
-            if (selector_name) {
-              transitionDuration = +Selectors[selector_name].duration || 0;
-            }
+            var transitionDuration = +Selectors[selector_name].duration || 0;
             groups.each(function(d) {
               var group = d3.select(this);
               // Select existing elements (if any)
@@ -1938,10 +1935,8 @@ var animint = function (to_select, json_file) {
           positionTooltip(tooltip, tooltip.html());
         });
     }
-    if(selector_name){
-      var milliseconds = Selectors[selector_name].duration;
-      elements = elements.transition().duration(milliseconds);
-    }
+    var milliseconds = Selectors[selector_name].duration;
+    elements = elements.transition().duration(milliseconds);
     if(g_info.aes.hasOwnProperty("id")){
       elements.attr("id", get_attr("id"));
     }
@@ -2086,7 +2081,7 @@ var animint = function (to_select, json_file) {
     // update existing axis
     var xyaxis_sel = element.select("#"+viz_id+"_"+p_name).select("."+axes+"axis_"+panel_i);
     var milliseconds = 0;
-    if(v_name && Selectors[v_name].hasOwnProperty("duration")){
+    if(Selectors[v_name].hasOwnProperty("duration")){
       milliseconds = Selectors[v_name].duration;
     }
     var xyaxis_g = xyaxis_sel

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -1642,7 +1642,7 @@ var animint = function (to_select, json_file) {
           eActions = function(groups) {
             // Handle transitions seperately due to unique structure of geom_label_aligned
             var transitionDuration = 0;
-            if (selector_name) {
+            if(selector_name && Selectors[selector_name].hasOwnProperty("duration")){
               transitionDuration = +Selectors[selector_name].duration || 0;
             }
             groups.each(function(d) {
@@ -1938,7 +1938,7 @@ var animint = function (to_select, json_file) {
           positionTooltip(tooltip, tooltip.html());
         });
     }
-    if(selector_name){
+    if(selector_name && Selectors[selector_name].hasOwnProperty("duration")){
       var milliseconds = Selectors[selector_name].duration;
       elements = elements.transition().duration(milliseconds);
     }

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -2086,7 +2086,7 @@ var animint = function (to_select, json_file) {
     // update existing axis
     var xyaxis_sel = element.select("#"+viz_id+"_"+p_name).select("."+axes+"axis_"+panel_i);
     var milliseconds = 0;
-    if(Selectors[v_name].hasOwnProperty("duration")){
+    if(v_name && Selectors.hasOwnProperty(v_name) && Selectors[v_name].hasOwnProperty("duration")){
       milliseconds = Selectors[v_name].duration;
     }
     var xyaxis_g = xyaxis_sel


### PR DESCRIPTION
Fixes #278 

- Replaced Selectors.hasOwnProperty(selector_name) with a simple selector_name check in draw_geom and geom_label_aligned. 
- Removed redundant guard in update_selector.
- Removed Selectors.hasOwnProperty check in update_axes.

I confirm I have not used any AI code generation tools for this PR.