### PR TITLE
Add failing test for quarto animint output copy

### DIFF
--- a/R/z_knitr.R
+++ b/R/z_knitr.R
@@ -12,6 +12,7 @@ knit_print.animint <- function(x, options, ...) {
   viz_id <- gsub("[^[:alnum:]]", "", options$label)
   out.dir <- file.path(output.dir, viz_id)
   animint2dir(x, out.dir = out.dir, open.browser = FALSE)
+  copy_quarto_animint_dir(out.dir, viz_id)
   res <- if(knitr::is_latex_output())sprintf(
     "\\IfFileExists{%s/Capture.PNG}{\\includegraphics[width=\\textwidth]{%s/Capture.PNG}}{}", out.dir, out.dir
   ) else sprintf(
@@ -34,6 +35,33 @@ knit_print.animint <- function(x, options, ...) {
 %s', viz_id, viz_id, viz_id, viz_id, viz_id, viz_id, viz_id, viz_id, viz_id, res)
   }
   knitr::asis_output(res, meta = list(animint = structure("", class = "animint")))
+}
+
+quarto_output_dir <- function(project.root) {
+  quarto.yml <- file.path(project.root, "_quarto.yml")
+  if (!file.exists(quarto.yml)) return(NULL)
+
+  yml.lines <- readLines(quarto.yml, warn = FALSE)
+  output.line <- grep("^[[:space:]]+output-dir:", yml.lines, value = TRUE)
+  if (!length(output.line)) return("_site")
+
+  sub("^[[:space:]]+output-dir:[[:space:]]*", "", output.line[[1]])
+}
+
+copy_quarto_animint_dir <- function(out.dir, viz_id) {
+  project.root <- Sys.getenv("QUARTO_PROJECT_ROOT")
+  if (project.root == "") return(invisible(FALSE))
+
+  output.dir <- quarto_output_dir(project.root)
+  if (is.null(output.dir)) return(invisible(FALSE))
+
+  site.dir <- file.path(project.root, output.dir)
+  if (!dir.exists(site.dir)) return(invisible(FALSE))
+
+  to.dir <- file.path(site.dir, viz_id)
+  if (dir.exists(to.dir)) unlink(to.dir, recursive = TRUE)
+
+  file.copy(out.dir, site.dir, recursive = TRUE)
 }
 
 #' Shiny ui output function

--- a/R/z_knitr.R
+++ b/R/z_knitr.R
@@ -12,17 +12,17 @@ knit_print.animint <- function(x, options, ...) {
   viz_id <- gsub("[^[:alnum:]]", "", options$label)
   out.dir <- file.path(output.dir, viz_id)
   animint2dir(x, out.dir = out.dir, open.browser = FALSE)
-  copy_quarto_animint_dir(out.dir, viz_id)
-  res <- if(knitr::is_latex_output())sprintf(
-    "\\IfFileExists{%s/Capture.PNG}{\\includegraphics[width=\\textwidth]{%s/Capture.PNG}}{}", out.dir, out.dir
-  ) else sprintf(
+  if(knitr::is_latex_output()){
+    res <- sprintf(
+      "\\IfFileExists{%s/Capture.PNG}{\\includegraphics[width=\\textwidth]{%s/Capture.PNG}}{}", out.dir, out.dir)
+  }else{
+    res <- sprintf(
     ## <div id="Ch01vizKeeling"></div><script>var Ch01vizKeeling = new animint("#Ch01vizKeeling","Ch01vizKeeling/plot.json");</script>
-    '<div id="%s"></div>\n<script>var %s = new animint("#%s","%s/plot.json");</script>', viz_id, viz_id, viz_id, viz_id
-  )
-  # if this is the first plot, place scripts just before the plot
-  # there has to be a better way to do this, but this will do for now -- http://stackoverflow.com/questions/14308240/how-to-add-javascript-in-the-head-of-a-html-knitr-document
-  if (length(knitr::knit_meta(class = "animint", clean = FALSE)) == 0) {
-    res <- sprintf('
+      '<div id="%s"></div>\n<script>var %s = new animint("#%s","%s/plot.json");</script>', viz_id, viz_id, viz_id, viz_id)
+    # if this is the first plot, place scripts just before the plot
+    # there has to be a better way to do this, but this will do for now -- http://stackoverflow.com/questions/14308240/how-to-add-javascript-in-the-head-of-a-html-knitr-document
+    if (length(knitr::knit_meta(class = "animint", clean = FALSE)) == 0) {
+      res <- sprintf('
 <script type="text/javascript" src="%s/vendor/d3.v3.js"></script>
 <script type="text/javascript" src="%s/animint.js"></script>
 <script type="text/javascript" src="%s/vendor/quadprog.js"></script>
@@ -33,35 +33,20 @@ knit_print.animint <- function(x, options, ...) {
 <script type="text/javascript" src="%s/vendor/driver.js.iife.js"></script>
 <link rel="stylesheet" href="%s/vendor/driver.css" />
 %s', viz_id, viz_id, viz_id, viz_id, viz_id, viz_id, viz_id, viz_id, viz_id, res)
+    }
+    res <- paste(res, animint_resources(out.dir, viz_id), sep = "\n")
   }
   knitr::asis_output(res, meta = list(animint = structure("", class = "animint")))
 }
 
-quarto_output_dir <- function(project.root) {
-  quarto.yml <- file.path(project.root, "_quarto.yml")
-  if (!file.exists(quarto.yml)) return(NULL)
-
-  yml.lines <- readLines(quarto.yml, warn = FALSE)
-  output.line <- grep("^[[:space:]]+output-dir:", yml.lines, value = TRUE)
-  if (!length(output.line)) return("_site")
-
-  sub("^[[:space:]]+output-dir:[[:space:]]*", "", output.line[[1]])
-}
-
-copy_quarto_animint_dir <- function(out.dir, viz_id) {
-  project.root <- Sys.getenv("QUARTO_PROJECT_ROOT")
-  if (project.root == "") return(invisible(FALSE))
-
-  output.dir <- quarto_output_dir(project.root)
-  if (is.null(output.dir)) return(invisible(FALSE))
-
-  site.dir <- file.path(project.root, output.dir)
-  if (!dir.exists(site.dir)) return(invisible(FALSE))
-
-  to.dir <- file.path(site.dir, viz_id)
-  if (dir.exists(to.dir)) unlink(to.dir, recursive = TRUE)
-
-  file.copy(out.dir, site.dir, recursive = TRUE)
+animint_resources <- function(out.dir, viz_id) {
+  files <- list.files(out.dir, recursive = TRUE, all.files = TRUE, no.. = TRUE)
+  files <- files[!dir.exists(file.path(out.dir, files))]
+  if(!length(files))return("")
+  hrefs <- file.path(viz_id, files)
+  hrefs <- gsub("\\\\", "/", hrefs)
+  links <- sprintf('<a href="%s"></a>', hrefs)
+  paste0('<div style="display:none">', paste(links, collapse = "\n"), '</div>')
 }
 
 #' Shiny ui output function

--- a/tests/testthat/test-compiler-knit-print-quarto.R
+++ b/tests/testthat/test-compiler-knit-print-quarto.R
@@ -1,0 +1,36 @@
+acontext("knitting quarto website outputs")
+
+test_that("quarto website output includes animint directory", {
+  skip_if_not_installed("quarto")
+  skip_if_not(nzchar(quarto::quarto_path()), "Quarto CLI not installed")
+
+  temp.dir <- tempfile()
+  dir.create(temp.dir)
+  on.exit(unlink(temp.dir, recursive = TRUE), add = TRUE)
+
+  writeLines(c(
+    "project:",
+    "  type: website",
+    "  output-dir: _site"
+  ), file.path(temp.dir, "_quarto.yml"))
+
+  writeLines(c(
+    "---",
+    "title: Home",
+    "---",
+    "",
+    "```{r myplot}",
+    "library(animint2)",
+    "p <- ggplot() + geom_point(aes(x = 1:10, y = 1:10))",
+    "animint(plot = p)",
+    "```"
+  ), file.path(temp.dir, "index.qmd"))
+
+  old_wd <- getwd()
+  setwd(temp.dir)
+  on.exit(setwd(old_wd), add = TRUE)
+
+  quarto::quarto_render("index.qmd", quiet = TRUE)
+
+  expect_true(file.exists(file.path(temp.dir, "_site", "myplot", "plot.json")))
+})

--- a/tests/testthat/test-compiler-knit-print-quarto.R
+++ b/tests/testthat/test-compiler-knit-print-quarto.R
@@ -33,4 +33,5 @@ test_that("quarto website output includes animint directory", {
   quarto::quarto_render("index.qmd", quiet = TRUE)
 
   expect_true(file.exists(file.path(temp.dir, "_site", "myplot", "plot.json")))
+  expect_true(file.exists(file.path(temp.dir, "_site", "myplot", "animint.js")))
 })


### PR DESCRIPTION
 ### Description

  This PR adds a failing test for #325.

  The test creates a small Quarto website project with one animint plot, renders it with `quarto::quarto_render()`, and checks
  for the generated animint files in `_site/myplot/`.

  On current `master`, the animint directory is created during knitting but is not copied into the Quarto website output
  directory, so the rendered site is missing files such as `plot.json`.

  No fix or NEWS entry is included yet. This is only the failing test commit, following the test-first workflow described in
  the contributing guide.