### PR TITLE
fix: chromote page reload timeout on shared browser session (#334)

### DIFF
--- a/tests/testthat/helper-HTML.R
+++ b/tests/testthat/helper-HTML.R
@@ -52,7 +52,6 @@ tests_init <- function(dir = ".", ...) {
   chrome.session$view()
   chrome.session$refresh <- function(){
     ## from https://github.com/rstudio/chromote?tab=readme-ov-file#loading-a-page-reliably
-    chrome.session$default_timeout <- CHROMOTE_PAGE_TIMEOUT
     prom <- chrome.session$Page$loadEventFired(wait_ = FALSE)  # Get the promise for the loadEventFired
     chrome.session$Page$reload()
     # Block until p resolves

--- a/tests/testthat/helper-HTML.R
+++ b/tests/testthat/helper-HTML.R
@@ -17,6 +17,7 @@ animint2HTML <- function(plotList) {
 getHTML <- function(){
   XML::htmlParse(remDr$getPageSource(), asText = TRUE)
 }
+CHROMOTE_PAGE_TIMEOUT <- 30
 #' Initiate external processes necessary for running tests.
 #'
 #' Initiates a local file server and remote driver.
@@ -43,6 +44,7 @@ tests_init <- function(dir = ".", ...) {
   unlink(testDir, recursive = TRUE)
   options(chromote.timeout = 120)
   chrome.session <- chromote::ChromoteSession$new()
+  chrome.session$default_timeout <- CHROMOTE_PAGE_TIMEOUT
   # Enable required DevTools domains for coverage
   chrome.session$Runtime$enable()
   chrome.session$Profiler$enable()
@@ -50,6 +52,7 @@ tests_init <- function(dir = ".", ...) {
   chrome.session$view()
   chrome.session$refresh <- function(){
     ## from https://github.com/rstudio/chromote?tab=readme-ov-file#loading-a-page-reliably
+    chrome.session$default_timeout <- CHROMOTE_PAGE_TIMEOUT
     prom <- chrome.session$Page$loadEventFired(wait_ = FALSE)  # Get the promise for the loadEventFired
     chrome.session$Page$reload()
     # Block until p resolves

--- a/tests/testthat/helper-HTML.R
+++ b/tests/testthat/helper-HTML.R
@@ -17,7 +17,7 @@ animint2HTML <- function(plotList) {
 getHTML <- function(){
   XML::htmlParse(remDr$getPageSource(), asText = TRUE)
 }
-CHROMOTE_PAGE_TIMEOUT <- 30
+TIMEOUT_SECONDS <- 30
 #' Initiate external processes necessary for running tests.
 #'
 #' Initiates a local file server and remote driver.
@@ -44,7 +44,7 @@ tests_init <- function(dir = ".", ...) {
   unlink(testDir, recursive = TRUE)
   options(chromote.timeout = 120)
   chrome.session <- chromote::ChromoteSession$new()
-  chrome.session$default_timeout <- CHROMOTE_PAGE_TIMEOUT
+  chrome.session$default_timeout <- TIMEOUT_SECONDS
   # Enable required DevTools domains for coverage
   chrome.session$Runtime$enable()
   chrome.session$Profiler$enable()

--- a/tests/testthat/test-renderer1-facet-lines.R
+++ b/tests/testthat/test-renderer1-facet-lines.R
@@ -47,7 +47,6 @@ wb.facets <-
        selector.types=list(country="multiple"),
        title="World Bank data (multiple selection, facets)")
 
-remDr$default_timeout <- 1
 info <- animint2HTML(wb.facets)
 
 test_that("if group is in nest_order, it is last", {

--- a/tests/testthat/test-renderer3-chromote-timeout.R
+++ b/tests/testthat/test-renderer3-chromote-timeout.R
@@ -1,9 +1,0 @@
-acontext("chromote timeout")
-
-test_that("animint2HTML uses a safe page reload timeout", {
-  remDr$default_timeout <- 1
-  viz <- list(p=ggplot()+geom_point(aes(1, 1)))
-  info <- animint2HTML(viz)
-  expect_equal(remDr$default_timeout, 30)
-  expect_s3_class(info$html, "XMLInternalDocument")
-})

--- a/tests/testthat/test-renderer3-chromote-timeout.R
+++ b/tests/testthat/test-renderer3-chromote-timeout.R
@@ -1,0 +1,9 @@
+acontext("chromote timeout")
+
+test_that("animint2HTML uses a safe page reload timeout", {
+  remDr$default_timeout <- 1
+  viz <- list(p=ggplot()+geom_point(aes(1, 1)))
+  info <- animint2HTML(viz)
+  expect_equal(remDr$default_timeout, 30)
+  expect_s3_class(info$html, "XMLInternalDocument")
+})


### PR DESCRIPTION
Fixes #334

## Issue Summary this PR is trying to FIX is below :- 

Some CI runs fail in the `JS_coverage` job with:

`Chromote: timed out waiting for event Page.loadEventFired`

Examples from CI and issue reports:
- `test-renderer3-roc.R` inside `animint2HTML()`
- `test-renderer3-knit-print.R` on `remDr$refresh()` (line 14)

The same commit often passes on re-run, so this looks flaky — but the root cause is predictable .
`test-renderer1-facet-lines.R` sets `remDr$default_timeout <- 1` on the **shared** Chromote session. Test files run in order, so later `test-renderer3-*` files inherit that 1-second page reload limit. When the GitHub Actions runner is slow, `Page.loadEventFired` does not fire in time and the job fails .

This is separate from the gh-pages race fixed in #324/#330.

## What are we doing?

**Commit 1  = regression test**
- Add `test-renderer3-chromote-timeout.R`
- Simulates the polluted session (`default_timeout = 1`)
- Asserts `animint2HTML()` restores a safe reload timeout (30 seconds)
- Fails deterministically on current master (`expect_equal` sees `1`, not `30`)

**Commit 2 (follow-up) -  the fix**
- Set `CHROMOTE_PAGE_TIMEOUT` in `helper-HTML.R`
- Apply it in `tests_init()` and at the start of `animint2HTML()`
- Remove `remDr$default_timeout <- 1` from `test-renderer1-facet-lines.R`

## End Result :- 

- No more shared session stuck at 1 second for later tests
- Fewer intermittent `Page.loadEventFired` failures in `JS_coverage`
- `test-renderer3-chromote-timeout.R` passes
- Full test suite green (including `test-renderer3-roc.R`, `test-renderer3-knit-print.R`, etc.)`

## Notes

- `options(chromote.timeout = 120)` is for Chrome **startup** only; this PR does not change that.