### PR TITLE
CI: skip ghpages integration tests on PR builds

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,6 +18,7 @@ jobs:
     env: 
       TEST_SUITE: ${{ matrix.test-suite }}
       GITHUB_PAT: ${{ secrets.PAT_GITHUB }}
+      ANIMINT2_TEST_GHPAGES: ${{ github.event_name == 'push' && '1' || '' }}
       GH_ACTION: "ENABLED"
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:

--- a/tests/testthat/helper-ghpages.R
+++ b/tests/testthat/helper-ghpages.R
@@ -1,0 +1,10 @@
+ghpages_tests_should_skip <- function() {
+  if (!nzchar(Sys.getenv("ANIMINT2_TEST_GHPAGES", unset = ""))) return(TRUE)
+  pat <- Sys.getenv("GITHUB_PAT", unset = "")
+  pat_com <- Sys.getenv("GITHUB_PAT_GITHUB_COM", unset = "")
+  !nzchar(pat) && !nzchar(pat_com)
+}
+
+skip_ghpages_integration <- function() {
+  skip_if(ghpages_tests_should_skip(), "ghpages CI setup not available")
+}

--- a/tests/testthat/test-compiler-ghpages.R
+++ b/tests/testthat/test-compiler-ghpages.R
@@ -56,7 +56,11 @@ test_that("ghpages integration skipped when ANIMINT2_TEST_GHPAGES unset", {
   env.old <- Sys.getenv(env.names, unset = NA)
   on.exit({
     for (n in env.names) {
-      if (is.na(env.old[n])) Sys.unsetenv(n) else Sys.setenv(setNames(env.old[n], n))
+      if (is.na(env.old[[n]])) {
+        Sys.unsetenv(n)
+      } else {
+        do.call(Sys.setenv, setNames(list(env.old[[n]]), n))
+      }
     }
   })
   Sys.unsetenv("ANIMINT2_TEST_GHPAGES")

--- a/tests/testthat/test-compiler-ghpages.R
+++ b/tests/testthat/test-compiler-ghpages.R
@@ -51,6 +51,22 @@ reset_test_repo <- function(){
   gh::gh("POST /orgs/animint-test/repos", name = test_repo_name)
   Sys.sleep(3)
 }
+## Skip API integration tests when ANIMINT2_TEST_GHPAGES or token env vars are missing.
+ghpages_tests_should_skip <- function() {
+  FALSE
+}
+test_that("ghpages integration skipped when ANIMINT2_TEST_GHPAGES unset", {
+  env.names <- c("ANIMINT2_TEST_GHPAGES", "GITHUB_PAT")
+  env.old <- Sys.getenv(env.names, unset = NA)
+  on.exit({
+    for (n in env.names) {
+      if (is.na(env.old[n])) Sys.unsetenv(n) else Sys.setenv(setNames(env.old[n], n))
+    }
+  })
+  Sys.unsetenv("ANIMINT2_TEST_GHPAGES")
+  Sys.setenv(GITHUB_PAT = "dummy-token")
+  expect_equal(ghpages_tests_should_skip(), TRUE)
+})
 test_that("animint2pages(chromote_sleep_seconds=3) creates Capture.PNG", {
   reset_test_repo()
   ## first run of animint2pages creates new data viz.

--- a/tests/testthat/test-compiler-ghpages.R
+++ b/tests/testthat/test-compiler-ghpages.R
@@ -51,10 +51,6 @@ reset_test_repo <- function(){
   gh::gh("POST /orgs/animint-test/repos", name = test_repo_name)
   Sys.sleep(3)
 }
-## Skip API integration tests when ANIMINT2_TEST_GHPAGES or token env vars are missing.
-ghpages_tests_should_skip <- function() {
-  FALSE
-}
 test_that("ghpages integration skipped when ANIMINT2_TEST_GHPAGES unset", {
   env.names <- c("ANIMINT2_TEST_GHPAGES", "GITHUB_PAT")
   env.old <- Sys.getenv(env.names, unset = NA)
@@ -68,6 +64,7 @@ test_that("ghpages integration skipped when ANIMINT2_TEST_GHPAGES unset", {
   expect_equal(ghpages_tests_should_skip(), TRUE)
 })
 test_that("animint2pages(chromote_sleep_seconds=3) creates Capture.PNG", {
+  skip_ghpages_integration()
   reset_test_repo()
   ## first run of animint2pages creates new data viz.
   result_list <- animint2pages(viz, test_repo_name, owner="animint-test", chromote_sleep_seconds=3)
@@ -95,6 +92,7 @@ test_that("animint2pages(chromote_sleep_seconds=3) creates Capture.PNG", {
 })
 
 test_that("animint2pages(chromote_sleep_seconds=NULL) does not create Capture.PNG", {
+  skip_ghpages_integration()
   reset_test_repo()
   Sys.sleep(3)
   result_list <- animint2pages(viz, test_repo_name, owner="animint-test", chromote_sleep_seconds=NULL)


### PR DESCRIPTION
This PR fixes the ghpages CI failure described in #335.

On pull request builds, especially from forks, the ghpages integration tests in `tests/testthat/test-compiler-ghpages.R` call the GitHub API through `reset_test_repo()`. Those tests need an admin token on the `animint-test` org. When that token is not available, CI fails with permission errors - even when the PR did not touch GitHub Pages.

The goal is to skip those integration tests when the required CI setup is missing, instead of failing the whole build with a misleading red X.

- Current failure: integration tests run and hit GitHub API without permission
<img width="893" height="685" alt="Screenshot From 2026-06-11 18-03-55" src="https://github.com/user-attachments/assets/6feb9a09-bf14-48b1-8429-e83abbbf945d" />

 - This PR does **not** change xvfb / JS_coverage, per @tdhock's feedback on #335.

**Commit plan**
- **Commit 1:** add `ghpages_tests_should_skip()` and a failing test that shows the skip gate is not implemented yet.
- **Commit 2:** implement the real skip logic, wire `skip_if()` on integration tests, and optionally set `ANIMINT2_TEST_GHPAGES` in the workflow for pushes to `master` only.

**Local note:** to run ghpages integration tests locally, you may need `ANIMINT2_TEST_GHPAGES=1` and a valid `GITHUB_PAT` exported.